### PR TITLE
Fix item and NPC examine messages ignoring examine chat toggle

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -66,6 +66,7 @@ Explore the many customization options to fine-tune your TTS experience:<br/>
  - Duplicate system messages won't be played every time anymore
  - Fixed issue where certain dialogs were not working (eg Spirit Tree)
  - NPC Dialogs now have an individual queue for NPC + Player dialog messages
+ - Fixed item and NPC examine messages not respecting the examine chat toggle
 
 
 ## 1.2.4

--- a/src/main/java/dev/phyce/naturalspeech/utils/ChatHelper.java
+++ b/src/main/java/dev/phyce/naturalspeech/utils/ChatHelper.java
@@ -147,6 +147,7 @@ public class ChatHelper {
 		switch (messageType) {
 			case NPC_EXAMINE:
 			case OBJECT_EXAMINE:
+			case ITEM_EXAMINE:
 				return true;
 			default:
 				return false;
@@ -264,6 +265,8 @@ public class ChatHelper {
 				if (!config.groupIronmanChatEnabled()) return true;
 				break;
 			case OBJECT_EXAMINE:
+			case ITEM_EXAMINE:
+			case NPC_EXAMINE:
 				if (!config.examineChatEnabled()) return true;
 				break;
 			case WELCOME:


### PR DESCRIPTION
## Summary
- Add `ITEM_EXAMINE` to the inner-voice routing in `ChatHelper.isInnerVoice` so item examines are read in the local player's voice like NPC/object examines.
- Gate `ITEM_EXAMINE` and `NPC_EXAMINE` on `config.examineChatEnabled()` in `ChatHelper.isBlocked` so the examine chat toggle now covers all three examine types (previously only `OBJECT_EXAMINE` was gated).
- Update FEATURES.md changelog under 1.3.0.

This is a back-port of the bugfix in upstream commit `69d989c` on master, minus a debug `System.out.println` that was in that commit.

## Test plan
- [ ] In game with examine chat enabled: examine an item, an object, and an NPC — all three should be voiced.
- [ ] Disable the examine chat option: examine the same three — none should be voiced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)