### PR TITLE
Fix numbers with commas in system messages

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -66,6 +66,7 @@ Explore the many customization options to fine-tune your TTS experience:<br/>
  - Duplicate system messages won't be played every time anymore
  - Fixed issue where certain dialogs were not working (eg Spirit Tree)
  - NPC Dialogs now have an individual queue for NPC + Player dialog messages
+ - Fixed numbers with commas in system messages not being read correctly
 
 
 ## 1.2.4

--- a/src/main/java/dev/phyce/naturalspeech/utils/ChatHelper.java
+++ b/src/main/java/dev/phyce/naturalspeech/utils/ChatHelper.java
@@ -15,6 +15,8 @@ import static dev.phyce.naturalspeech.utils.Locations.inGrandExchange;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.inject.Inject;
 import lombok.AllArgsConstructor;
 import lombok.NonNull;
@@ -311,9 +313,25 @@ public class ChatHelper {
 
 	@NonNull
 	public String standardizeChatMessageText(@NonNull ChatMessage message) {
-		String text = renderReplacements(message.getMessage());
+		String text = message.getMessage();
+		if (getChatType(message) == ChatType.System) {
+			text = removeNumericCommas(text);
+		}
+		text = renderReplacements(text);
 		text = Texts.renderLargeNumbers(text);
 		return text;
+	}
+
+	private static final Pattern NUMERIC_COMMA_PATTERN = Pattern.compile("\\d{1,3}(,\\d{3})+");
+
+	public static String removeNumericCommas(String input) {
+		Matcher matcher = NUMERIC_COMMA_PATTERN.matcher(input);
+		StringBuilder result = new StringBuilder();
+		while (matcher.find()) {
+			matcher.appendReplacement(result, matcher.group().replace(",", ""));
+		}
+		matcher.appendTail(result);
+		return result.toString();
 	}
 
 	@NonNull


### PR DESCRIPTION
## Summary
- Add `removeNumericCommas` helper that strips thousand-separator commas from runs of digits like `1,000,000` → `1000000`.
- Call it in `standardizeChatMessageText` when the message's `ChatType` is `System`, before the abbreviation/large-number pipeline runs.

This is a back-port of upstream commit `23402a3` on master. Adapted to keep the existing single-arg `standardizeChatMessageText(ChatMessage)` signature on 1.3.0 (the upstream commit changed it to two args).

## Test plan
- [ ] Receive a drop / GE notification with a value like `1,000,000` — should be voiced as one million.
- [ ] Public/clan chat containing "1,000" should be unaffected (only System messages are touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)