### PR TITLE
Gate clan/gim/guest system messages on their channel toggle

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -66,6 +66,7 @@ Explore the many customization options to fine-tune your TTS experience:<br/>
  - Duplicate system messages won't be played every time anymore
  - Fixed issue where certain dialogs were not working (eg Spirit Tree)
  - NPC Dialogs now have an individual queue for NPC + Player dialog messages
+ - Clan / clan guest / group iron system messages now also respect the matching channel toggle
 
 
 ## 1.2.4

--- a/src/main/java/dev/phyce/naturalspeech/utils/ChatHelper.java
+++ b/src/main/java/dev/phyce/naturalspeech/utils/ChatHelper.java
@@ -269,9 +269,18 @@ public class ChatHelper {
 			case WELCOME:
 			case LOGINLOGOUTNOTIFICATION:
 			case GAMEMESSAGE:
+				if (!config.systemMesagesEnabled()) return true;
+				break;
 			case CLAN_MESSAGE:
+				if (!config.clanChatEnabled()) return true;
+				if (!config.systemMesagesEnabled()) return true;
+				break;
 			case CLAN_GIM_MESSAGE:
+				if (!config.groupIronmanChatEnabled()) return true;
+				if (!config.systemMesagesEnabled()) return true;
+				break;
 			case CLAN_GUEST_MESSAGE:
+				if (!config.clanGuestChatEnabled()) return true;
 				if (!config.systemMesagesEnabled()) return true;
 				break;
 			case TRADEREQ:


### PR DESCRIPTION
## Summary
- `CLAN_MESSAGE`, `CLAN_GIM_MESSAGE`, and `CLAN_GUEST_MESSAGE` were only gated on the global system-messages toggle. Now each one also requires the corresponding channel toggle (`Clan chat`, `Group iron chat`, `Clan guest chat`) to be enabled before being voiced.

Refs upstream commit `1199e1f` on master. Extended to also gate the GIM and guest system message buckets for consistency.

## Test plan
- [ ] With `Clan chat` disabled, in-clan login/logout system notifications should not be voiced.
- [ ] With `Clan chat` enabled and `System messages` disabled, the same notifications should remain silent.
- [ ] With both enabled, they should be voiced normally.
- [ ] Verify the same for `Clan guest` and `Group ironman` channels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)