### PR TITLE
Make Global NPC voice override per-NPC voice settings again

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -66,6 +66,7 @@ Explore the many customization options to fine-tune your TTS experience:<br/>
  - Duplicate system messages won't be played every time anymore
  - Fixed issue where certain dialogs were not working (eg Spirit Tree)
  - NPC Dialogs now have an individual queue for NPC + Player dialog messages
+ - `Global NPC voice` now properly overrides per-NPC voice settings again
 
 
 ## 1.2.4

--- a/src/main/java/dev/phyce/naturalspeech/entity/EntityID.java
+++ b/src/main/java/dev/phyce/naturalspeech/entity/EntityID.java
@@ -31,7 +31,7 @@ public final class EntityID {
 	 */
 	static final int VERSION = 1;
 
-	final Integer id;
+	public final Integer id;
 	final String name;
 
 	private EntityID(@Nullable Integer id, @Nullable String name) {

--- a/src/main/java/dev/phyce/naturalspeech/texttospeech/VoiceManager.java
+++ b/src/main/java/dev/phyce/naturalspeech/texttospeech/VoiceManager.java
@@ -125,7 +125,6 @@ public class VoiceManager {
 	public VoiceID resolve(@NonNull EntityID entityID) {
 		Preconditions.checkState(!activeVoiceMap.isEmpty(), "No active voices.");
 
-		// if there is setting for this entity, use that
 		VoiceID voiceID = settings.get(entityID);
 
 		if (voiceID != null && !activeVoiceMap.contains(voiceID)) {
@@ -133,7 +132,15 @@ public class VoiceManager {
 			voiceID = null;
 		}
 
-		// no settings, randomize
+		// Global NPC voice overrides any per-NPC setting when the entity is an NPC.
+		if (entityID.id != null && settings.containsKey(EntityID.GLOBAL_NPC)) {
+			VoiceID globalVoice = settings.get(EntityID.GLOBAL_NPC);
+			if (globalVoice != null && activeVoiceMap.contains(globalVoice)) {
+				log.trace("Using global NPC voice for {}: {}", entityID, globalVoice);
+				return globalVoice;
+			}
+		}
+
 		if (voiceID == null) {
 			log.trace("No voice setting for {}. Randomizing voice.", entityID);
 			voiceID = random(entityID);


### PR DESCRIPTION
## Summary
- `Global NPC voice` was being shadowed by any pre-existing per-NPC voice setting in `VoiceManager.resolve`. Restore the documented override behavior: when the entity is an NPC and a global voice is set and active, the global voice wins.
- Promote `EntityID#id` to `public` so cross-package callers (VoiceManager) can detect NPC entities. Matches the same field on master.
- Update FEATURES.md changelog.

Refs upstream commit `9889ae3` on master.

## Test plan
- [ ] Set a specific NPC's voice via right-click → Voice → Configure.
- [ ] Set `Global NPC voice` to a different voice.
- [ ] Trigger that NPC's dialog/overhead — it should use the Global NPC voice, not the per-NPC voice.
- [ ] Clear the Global NPC voice — the per-NPC voice should be used again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)