### PR TITLE
Migrate right-click submenus to the current RuneLite submenu API

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -66,6 +66,7 @@ Explore the many customization options to fine-tune your TTS experience:<br/>
  - Duplicate system messages won't be played every time anymore
  - Fixed issue where certain dialogs were not working (eg Spirit Tree)
  - NPC Dialogs now have an individual queue for NPC + Player dialog messages
+ - Right-click submenus migrated to the current RuneLite submenu API
 
 
 ## 1.2.4

--- a/src/main/java/dev/phyce/naturalspeech/clienteventhandlers/MenuEventHandler.java
+++ b/src/main/java/dev/phyce/naturalspeech/clienteventhandlers/MenuEventHandler.java
@@ -27,6 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Actor;
 import net.runelite.api.Client;
 import net.runelite.api.KeyCode;
+import net.runelite.api.Menu;
 import net.runelite.api.MenuAction;
 import net.runelite.api.MenuEntry;
 import net.runelite.api.NPC;
@@ -105,7 +106,9 @@ public class MenuEventHandler {
 				&& Text.removeFormattingTags(entry.getOption()).contains("Set chat mode: Public")) {
 				MenuEntry parent = client.createMenuEntry(index)
 					.setTarget(icons.unmute.get() + "Set Volume")
-					.setType(MenuAction.RUNELITE_SUBMENU);
+					.setType(MenuAction.RUNELITE);
+
+				Menu subMenu = parent.createSubMenu();
 
 				final String[] colorScheme = new String[] {
 					"808080",
@@ -127,8 +130,7 @@ public class MenuEventHandler {
 					final int volume = i * 10;
 					final String colorTag = "<col=" + colorScheme[i] + ">";
 					final String meter = i == currentVolumeIndex ? "> " : "- ";
-					client.createMenuEntry(0)
-						.setParent(parent)
+					subMenu.createMenuEntry(0)
 						.setTarget(meter + colorTag + volume + "%")
 						.setType(MenuAction.RUNELITE)
 						.onClick(
@@ -156,12 +158,14 @@ public class MenuEventHandler {
 						_drawVoiceMenu(null, result, 0, MenuAction.RUNELITE);
 					}
 					else {
-						MenuEntry parent = _drawVoiceMenu(null, result, 0, MenuAction.RUNELITE_SUBMENU);
+						MenuEntry parent = _drawVoiceMenu(null, result, 0, MenuAction.RUNELITE);
+
+						Menu subMenu = parent.createSubMenu();
 
 						for (VoiceConfigMenu child : result.children) {
 							Preconditions.checkNotNull(child);
 
-							_drawVoiceMenu(parent, child, 0, MenuAction.RUNELITE);
+							_drawVoiceMenu(subMenu, child, 0, MenuAction.RUNELITE);
 						}
 					}
 				}
@@ -169,17 +173,20 @@ public class MenuEventHandler {
 		}
 	}
 
-	private MenuEntry _drawVoiceMenu(MenuEntry parent, VoiceConfigMenu tab, int index, MenuAction menuType) {
+	private MenuEntry _drawVoiceMenu(Menu subMenu, VoiceConfigMenu tab, int index, MenuAction menuType) {
 
 		String iconTag = drawIconTag(tab.icon, true);
 
 		String action = tab.actionName;
 
-		return client.createMenuEntry(index + 1)
+		MenuEntry entry = subMenu != null
+			? subMenu.createMenuEntry(index + 1)
+			: client.createMenuEntry(index + 1);
+
+		return entry
 			.setOption(iconTag + action)
 			.setTarget(tab.targetName)
 			.setType(menuType)
-			.setParent(parent)
 			.onClick(e -> {
 				if (tab.entityID == null) return;
 				if (tab.configKey == null) return;
@@ -209,12 +216,14 @@ public class MenuEventHandler {
 						_drawMuteMenu(null, result, 0, MenuAction.RUNELITE);
 					}
 					else {
-						MenuEntry parent = _drawMuteMenu(null, result, 0, MenuAction.RUNELITE_SUBMENU);
+						MenuEntry parent = _drawMuteMenu(null, result, 0, MenuAction.RUNELITE);
+
+						Menu subMenu = parent.createSubMenu();
 
 						for (TabConfigMenu child : result.children) {
 							Preconditions.checkNotNull(child);
 
-							_drawMuteMenu(parent, child, 0, MenuAction.RUNELITE);
+							_drawMuteMenu(subMenu, child, 0, MenuAction.RUNELITE);
 						}
 					}
 				}
@@ -242,7 +251,7 @@ public class MenuEventHandler {
 		}
 	}
 
-	private MenuEntry _drawMuteMenu(MenuEntry parent, TabConfigMenu tab, int index, MenuAction menuType) {
+	private MenuEntry _drawMuteMenu(Menu subMenu, TabConfigMenu tab, int index, MenuAction menuType) {
 		final boolean state = Arrays.stream(tab.configKeys)
 			.anyMatch(key -> configManager.getConfiguration(CONFIG_GROUP, key, boolean.class));
 
@@ -250,11 +259,14 @@ public class MenuEventHandler {
 
 		String action = state ? tab.falseAction : tab.trueAction;
 
-		return client.createMenuEntry(index + 1)
+		MenuEntry entry = subMenu != null
+			? subMenu.createMenuEntry(index + 1)
+			: client.createMenuEntry(index + 1);
+
+		return entry
 			.setOption(iconTag + action)
 			.setTarget(tab.name)
 			.setType(menuType)
-			.setParent(parent)
 			.onClick(e -> Arrays.stream(tab.configKeys)
 				.forEach(key -> configManager.setConfiguration(CONFIG_GROUP, key, !state))
 			);
@@ -347,62 +359,58 @@ public class MenuEventHandler {
 		MenuEntry parent = client.createMenuEntry(index + 1)
 			.setOption(status + "Voice")
 			.setTarget(target)
-			.setType(MenuAction.RUNELITE_SUBMENU);
+			.setType(MenuAction.RUNELITE);
+
+		Menu subMenu = parent.createSubMenu();
 
 		{
 			final String value = voiceID.toVoiceIDString();
-			MenuEntry configVoiceEntry = client.createMenuEntry(1)
+			subMenu.createMenuEntry(0)
 				.setOption("Configure")
 				.setType(MenuAction.RUNELITE)
 				.onClick(e -> voiceConfigChatboxTextInputProvider.get()
 					.entityID(entityID)
 					.value(value)
 					.build());
-			configVoiceEntry.setParent(parent);
 		}
 		if (muteManager.isListenMode()) {
-			MenuEntry stopListenEntry = client.createMenuEntry(1)
+			subMenu.createMenuEntry(0)
 				.setOption("Stop Listen Mode")
 				.setType(MenuAction.RUNELITE)
 				.onClick(e -> {
 					muteManager.setListenMode(false);
 					muteManager.clearListens();
 				});
-			stopListenEntry.setParent(parent);
 		}
 		else {
 			if (!isUnmuted) {
-				MenuEntry muteEntry = client.createMenuEntry(1)
+				subMenu.createMenuEntry(0)
 					.setOption("Mute")
 					.setType(MenuAction.RUNELITE)
 					.onClick(e -> {
 						muteManager.mute(entityID);
 						speechManager.silence(name -> name.equals(String.valueOf(entityID.hashCode())));
 					});
-				muteEntry.setParent(parent);
-
 			}
 			else {
-				MenuEntry unmuteEntry = client.createMenuEntry(1)
+				subMenu.createMenuEntry(0)
 					.setOption("Unmute")
 					.setType(MenuAction.RUNELITE)
 					.onClick(e -> muteManager.unmute(entityID));
-				unmuteEntry.setParent(parent);
 			}
 		}
 
 		if (isListened) {
-			MenuEntry unlistenEntry = client.createMenuEntry(0)
+			subMenu.createMenuEntry(0)
 				.setOption("Unlisten")
 				.setType(MenuAction.RUNELITE)
 				.onClick(e -> {
 					muteManager.unlisten(entityID);
 					speechManager.silenceAll();
 				});
-			unlistenEntry.setParent(parent);
 		}
 		else {
-			MenuEntry listenEntry = client.createMenuEntry(0)
+			subMenu.createMenuEntry(0)
 				.setOption("Listen")
 				.setType(MenuAction.RUNELITE)
 				.onClick(e -> {
@@ -410,7 +418,6 @@ public class MenuEventHandler {
 					muteManager.setListenMode(true);
 					speechManager.silenceAll();
 				});
-			listenEntry.setParent(parent);
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Replace the deprecated `MenuEntry#setParent` + `MenuAction.RUNELITE_SUBMENU` pattern with the current `parent.createSubMenu().createMenuEntry(...)` pattern across `MenuEventHandler`.
- Affects: chatbox volume submenu, voice-config submenus, mute/tab submenus, and per-entity (player/NPC) right-click submenus.
- Update FEATURES.md changelog.

Refs upstream commit `c3a5861` on master.

## Test plan
- [ ] Right-click on a chatbox tab (`Set chat mode: Public`) — Set Volume submenu should appear with the volume entries.
- [ ] Right-click `Game: Filter` / `Public: Show autochat` / `Clan: Show all` / `Private: Show all` / `Channel: Show all` / `Group: Show all` — Mute submenus should appear with their child entries.
- [ ] Right-click `Set chat mode: Public` and pick `Voice -> Configure` — the voice config submenu appears.
- [ ] Right-click on a player and an NPC — `Voice` submenu appears with Configure / Mute / Listen entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)