### PR TITLE
Apply Mute Grand Exchange to NPC overhead text as well

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -66,6 +66,7 @@ Explore the many customization options to fine-tune your TTS experience:<br/>
  - Duplicate system messages won't be played every time anymore
  - Fixed issue where certain dialogs were not working (eg Spirit Tree)
  - NPC Dialogs now have an individual queue for NPC + Player dialog messages
+ - `Mute Grand Exchange` now also mutes NPC overhead text in the GE
 
 
 ## 1.2.4

--- a/src/main/java/dev/phyce/naturalspeech/clienteventhandlers/SpeechEventHandler.java
+++ b/src/main/java/dev/phyce/naturalspeech/clienteventhandlers/SpeechEventHandler.java
@@ -122,6 +122,8 @@ public class SpeechEventHandler {
 
 		if (!config.npcOverheadEnabled()) return;
 
+		if (chatHelper.isAreaDisabled()) return;
+
 		NPC npc = (NPC) event.getActor();
 		EntityID entityID = EntityID.npc(npc);
 

--- a/src/main/java/dev/phyce/naturalspeech/utils/ChatHelper.java
+++ b/src/main/java/dev/phyce/naturalspeech/utils/ChatHelper.java
@@ -301,7 +301,7 @@ public class ChatHelper {
 		return config.muteCrowds() > 0 && config.muteCrowds() < count;
 	}
 
-	private boolean isAreaDisabled() {
+	public boolean isAreaDisabled() {
 		if (client.getLocalPlayer() == null) return false;
 		//noinspection RedundantIfStatement
 		if (config.muteGrandExchange() && inGrandExchange(client.getLocalPlayer().getWorldLocation())) return true;


### PR DESCRIPTION
## Summary
- `OverheadTextChanged` for NPCs bypassed the area-disabled check, so toggling `Mute Grand Exchange` silenced GE NPC chat-messages but not their overhead text.
- Add the same `chatHelper.isAreaDisabled()` gate to NPC overhead handling, and promote `isAreaDisabled` to `public`.
- Update FEATURES.md changelog.

Refs upstream commit `470dc49` on master.

## Test plan
- [ ] Enable `Mute Grand Exchange`, stand in GE — NPC overhead text (e.g. shopkeeper yells) should be silent.
- [ ] Walk outside GE with the setting on — NPC overhead text should be audible again.
- [ ] Disable `Mute Grand Exchange`, stand in GE — NPC overhead text should be audible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)