### PR TITLE
Strip rich-text tags from system messages before speaking (#6)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -66,6 +66,7 @@ Explore the many customization options to fine-tune your TTS experience:<br/>
  - Duplicate system messages won't be played every time anymore
  - Fixed issue where certain dialogs were not working (eg Spirit Tree)
  - NPC Dialogs now have an individual queue for NPC + Player dialog messages
+ - Stripped rich-text/colour tags from system messages before speaking
 
 
 ## 1.2.4

--- a/src/main/java/dev/phyce/naturalspeech/utils/ChatHelper.java
+++ b/src/main/java/dev/phyce/naturalspeech/utils/ChatHelper.java
@@ -311,7 +311,11 @@ public class ChatHelper {
 
 	@NonNull
 	public String standardizeChatMessageText(@NonNull ChatMessage message) {
-		String text = renderReplacements(message.getMessage());
+		String text = message.getMessage();
+		if (getChatType(message) == ChatType.System) {
+			text = Text.removeFormattingTags(text);
+		}
+		text = renderReplacements(text);
 		text = Texts.renderLargeNumbers(text);
 		return text;
 	}


### PR DESCRIPTION
## Summary
- Run `Text.removeFormattingTags` on system messages in `standardizeChatMessageText` so colour/formatting tags like `<col=ffff00>` don't get voiced literally.
- Player chat continues to bypass this since other code paths already handle player formatting.
- Update FEATURES.md changelog.

Refs upstream commit `6e9827f` on master; addresses issue #6 (rich-text in system messages).

Note: this PR introduces the System-message branch in `standardizeChatMessageText`. PR #28 (numeric commas) also introduces this branch; whichever lands first will require the other to rebase trivially.

## Test plan
- [ ] Spawn a system message containing `<col=...>` (e.g. drop notifications, GE notifications) — should be voiced without the tag.
- [ ] Public/clan/PM chat should still read normally (no double-strip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)