### PR TITLE
Recognise Latin-1 diacritics as alphanumeric

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -66,6 +66,7 @@ Explore the many customization options to fine-tune your TTS experience:<br/>
  - Duplicate system messages won't be played every time anymore
  - Fixed issue where certain dialogs were not working (eg Spirit Tree)
  - NPC Dialogs now have an individual queue for NPC + Player dialog messages
+ - Recognise Latin-1 diacritics (ä, é, ñ, …) as alphanumeric so accented messages no longer get muted
 
 
 ## 1.2.4

--- a/src/main/java/dev/phyce/naturalspeech/utils/Texts.java
+++ b/src/main/java/dev/phyce/naturalspeech/utils/Texts.java
@@ -36,7 +36,7 @@ public final class Texts {
 		return text;
 	}
 
-	public static final Pattern patternAnyAlphaNumericChar = Pattern.compile(".*\\w.*");
+	public static final Pattern patternAnyAlphaNumericChar = Pattern.compile(".*[A-Za-zÀ-ÖØ-öø-ÿ].*");
 
 	public static boolean containAlphaNumeric(String text) {
 		return patternAnyAlphaNumericChar.matcher(text).matches();


### PR DESCRIPTION
## Summary
- The `containAlphaNumeric` check used `\w` (ASCII only). Messages composed entirely of accented Latin-1 characters (ä, é, ñ, …) were treated as empty and dropped by the mute pipeline.
- Widen the pattern to `[A-Za-zÀ-ÖØ-öø-ÿ]` to cover the Latin-1 supplement letter range.
- Update FEATURES.md changelog.

Refs upstream commit `6e9827f` on master.

## Test plan
- [ ] Public-chat message containing only accented letters (e.g. \"Héllo\") should be voiced.
- [ ] A message like \"::::))))\" (no alphanumeric) should still be muted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)