### PR TITLE
Replace deprecated client.getPlayers / getCachedPlayers

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -66,6 +66,7 @@ Explore the many customization options to fine-tune your TTS experience:<br/>
  - Duplicate system messages won't be played every time anymore
  - Fixed issue where certain dialogs were not working (eg Spirit Tree)
  - NPC Dialogs now have an individual queue for NPC + Player dialog messages
+ - Replaced deprecated `client.getPlayers()` / `getCachedPlayers()` usage with the world view API
 
 
 ## 1.2.4

--- a/src/main/java/dev/phyce/naturalspeech/audio/VolumeManager.java
+++ b/src/main/java/dev/phyce/naturalspeech/audio/VolumeManager.java
@@ -54,7 +54,7 @@ public class VolumeManager {
 		this.config = config;
 
 		spawnedActors.addAll(client.getNpcs());
-		spawnedActors.addAll(client.getPlayers());
+		client.getTopLevelWorldView().players().forEach(spawnedActors::add);
 	}
 
 	@NonNull

--- a/src/main/java/dev/phyce/naturalspeech/utils/ChatHelper.java
+++ b/src/main/java/dev/phyce/naturalspeech/utils/ChatHelper.java
@@ -291,7 +291,8 @@ public class ChatHelper {
 		Player localPlayer = client.getLocalPlayer();
 		if (localPlayer == null) return false;
 
-		int count = (int) client.getPlayers().stream()
+		long count = java.util.stream.StreamSupport.stream(
+				client.getTopLevelWorldView().players().spliterator(), false)
 			// Exclude the local player themselves
 			.filter(player -> player != localPlayer)
 			// For example, within 15 tiles

--- a/src/main/java/dev/phyce/naturalspeech/utils/ClientHelper.java
+++ b/src/main/java/dev/phyce/naturalspeech/utils/ClientHelper.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import javax.inject.Inject;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -32,11 +33,14 @@ public final class ClientHelper {
 
 		if (eid.isUser()) return Optional.of(client.getLocalPlayer());
 
-		return Optional.fromJavaUtil(Arrays.stream(client.getCachedPlayers())
-			.filter(Objects::nonNull)
-			.filter(player -> player.getName() != null)
-			.filter(eid::isPlayer)
-			.findFirst());
+		return Optional.fromJavaUtil(
+			StreamSupport.stream(client.getTopLevelWorldView().players().spliterator(), false)
+				.map(player -> (Player) player)
+				.filter(Objects::nonNull)
+				.filter(player -> player.getName() != null)
+				.filter(eid::isPlayer)
+				.findFirst()
+		);
 	}
 
 	@NonNull


### PR DESCRIPTION
## Summary
- `client.getPlayers()` (VolumeManager, ChatHelper) and `client.getCachedPlayers()` (ClientHelper) are deprecated; route the three call sites through `client.getTopLevelWorldView().players()` so the plugin keeps working as RuneLite removes the old accessors.
- Update FEATURES.md changelog.

Refs upstream commits `9e7253d` and `e1095f0` on master.

## Test plan
- [ ] Plugin starts without errors after this change.
- [ ] Distance-fade and crowd-mute behaviours are unchanged.
- [ ] `getPlayer(EntityID)` resolves the correct in-world player for chat (used for player-specific volume).

🤖 Generated with [Claude Code](https://claude.com/claude-code)