### PR TITLE
Add Discord help link to main settings panel

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -66,6 +66,7 @@ Explore the many customization options to fine-tune your TTS experience:<br/>
  - Duplicate system messages won't be played every time anymore
  - Fixed issue where certain dialogs were not working (eg Spirit Tree)
  - NPC Dialogs now have an individual queue for NPC + Player dialog messages
+ - Added a Discord help link to the main settings panel
 
 
 ## 1.2.4

--- a/src/main/java/dev/phyce/naturalspeech/userinterface/panels/MainSettingsPanel.java
+++ b/src/main/java/dev/phyce/naturalspeech/userinterface/panels/MainSettingsPanel.java
@@ -338,6 +338,24 @@ public class MainSettingsPanel extends PluginPanel {
 		instructionsLink.setBorder(new EmptyBorder(0, 0, 5, 0));
 		mainContentPanel.add(instructionsLink);
 
+		// Discord Link
+		JLabel discordLink =
+			new JLabel("<html>Ask for help on our <a style=\"color:#7289da\" href='#'>Discord</a></html>", JLabel.CENTER);
+
+		discordLink.setCursor(new Cursor(Cursor.HAND_CURSOR));
+		discordLink.addMouseListener(new MouseAdapter() {
+			@Override
+			public void mouseClicked(MouseEvent e) {
+				try {
+					Desktop.getDesktop().browse(new URI("https://discord.gg/smhQRcyXVU"));
+				} catch (Exception ex) {
+					log.error("Error opening Discord link.", ex);
+				}
+			}
+		});
+		discordLink.setBorder(new EmptyBorder(0, 0, 5, 0));
+		mainContentPanel.add(discordLink);
+
 		{
 			warningStopped = new JPanel();
 			warningStopped.setVisible(false);


### PR DESCRIPTION
## Summary
- Adds a clickable "Ask for help on our Discord" link beneath the existing instructions link, opening `https://discord.gg/smhQRcyXVU` in the user's default browser.
- Update FEATURES.md changelog.

Refs upstream commit `86390ea` on master.

## Test plan
- [ ] Open the Natural Speech side panel — Discord link appears below the instructions link.
- [ ] Click the Discord link — default browser opens the invite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)