### PR TITLE
Add 'Player dialogs' toggle (issue #23)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -66,6 +66,7 @@ Explore the many customization options to fine-tune your TTS experience:<br/>
  - Duplicate system messages won't be played every time anymore
  - Fixed issue where certain dialogs were not working (eg Spirit Tree)
  - NPC Dialogs now have an individual queue for NPC + Player dialog messages
+ - Added `Player dialogs` toggle so you can mute your own dialog voice while still hearing NPCs
 
 
 ## 1.2.4

--- a/src/main/java/dev/phyce/naturalspeech/NaturalSpeechConfig.java
+++ b/src/main/java/dev/phyce/naturalspeech/NaturalSpeechConfig.java
@@ -233,6 +233,17 @@ public interface NaturalSpeechConfig extends Config {
 	}
 
 	@ConfigItem(
+		keyName=ConfigKeys.PLAYER_DIALOG,
+		name="Player dialogs",
+		description="Enable text-to-speech for your own dialog lines (disable to spam through quest dialog while still hearing NPCs)",
+		section=ttsOptionsSection,
+		position=81
+	)
+	default boolean playerDialogEnabled() {
+		return true;
+	}
+
+	@ConfigItem(
 		keyName=ConfigKeys.REQUESTS,
 		name="Trade/Challenge requests",
 		description="Enable text-to-speech to trade and challenge requests",

--- a/src/main/java/dev/phyce/naturalspeech/clienteventhandlers/SpeechEventHandler.java
+++ b/src/main/java/dev/phyce/naturalspeech/clienteventhandlers/SpeechEventHandler.java
@@ -105,7 +105,10 @@ public class SpeechEventHandler {
 		if (!config.dialogEnabled()) return;
 		if (!speechManager.isStarted()) return;
 
-		if (event.getGroupId() == InterfaceID.DIALOG_PLAYER) _speakDialogPlayer();
+		if (event.getGroupId() == InterfaceID.DIALOG_PLAYER) {
+			if (!config.playerDialogEnabled()) return;
+			_speakDialogPlayer();
+		}
 		else if (event.getGroupId() == InterfaceID.DIALOG_NPC) _speakDialogNPC();
 	}
 

--- a/src/main/java/dev/phyce/naturalspeech/statics/ConfigKeys.java
+++ b/src/main/java/dev/phyce/naturalspeech/statics/ConfigKeys.java
@@ -20,6 +20,7 @@ public interface ConfigKeys {
 	String EXAMINE_CHAT = "examineChat";
 	String NPC_OVERHEAD = "npcOverhead";
 	String DIALOG = "dialog";
+	String PLAYER_DIALOG = "playerDialog";
 	String REQUESTS = "requests";
 	String SYSTEM_MESSAGES = "systemMessages";
 	String MUTE_GRAND_EXCHANGE = "muteGrandExchange";


### PR DESCRIPTION
## Summary
- New `playerDialogEnabled` config option (TTS Options → Player dialogs, default on) that gates voicing of the player's own dialog lines.
- `SpeechEventHandler.onWidgetLoaded` skips `_speakDialogPlayer` when the toggle is off; NPC dialog continues to fire normally.

Closes #23.

## Test plan
- [ ] With `Player dialogs` enabled (default): trigger a quest dialog with player lines — both NPC and player voices are heard.
- [ ] Toggle off: only NPC dialog is voiced; the player's lines are silent.
- [ ] Other speech paths (public chat, examine, system messages) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)