### PR TITLE
Add RuneLite Twitch plugin integration

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -66,6 +66,7 @@ Explore the many customization options to fine-tune your TTS experience:<br/>
  - Duplicate system messages won't be played every time anymore
  - Fixed issue where certain dialogs were not working (eg Spirit Tree)
  - NPC Dialogs now have an individual queue for NPC + Player dialog messages
+ - Added optional integration with the RuneLite Twitch plugin (toggle in TTS Options)
 
 
 ## 1.2.4

--- a/src/main/java/dev/phyce/naturalspeech/NaturalSpeechConfig.java
+++ b/src/main/java/dev/phyce/naturalspeech/NaturalSpeechConfig.java
@@ -253,6 +253,17 @@ public interface NaturalSpeechConfig extends Config {
 	default boolean systemMesagesEnabled() {
 		return false;
 	}
+
+	@ConfigItem(
+		keyName=ConfigKeys.TWITCH_CHAT,
+		name="Twitch chat plugin",
+		description="Generate text-to-speech of messages received via the RuneLite Twitch plugin",
+		section=ttsOptionsSection,
+		position=110
+	)
+	default boolean twitchChatEnabled() {
+		return false;
+	}
 	// endregion
 
 	// region Mute Options

--- a/src/main/java/dev/phyce/naturalspeech/statics/ConfigKeys.java
+++ b/src/main/java/dev/phyce/naturalspeech/statics/ConfigKeys.java
@@ -22,6 +22,7 @@ public interface ConfigKeys {
 	String DIALOG = "dialog";
 	String REQUESTS = "requests";
 	String SYSTEM_MESSAGES = "systemMessages";
+	String TWITCH_CHAT = "twitchChat";
 	String MUTE_GRAND_EXCHANGE = "muteGrandExchange";
 	String MUTE_SELF = "muteSelf";
 	String MUTE_OTHERS = "muteOthers";

--- a/src/main/java/dev/phyce/naturalspeech/utils/ChatHelper.java
+++ b/src/main/java/dev/phyce/naturalspeech/utils/ChatHelper.java
@@ -173,6 +173,10 @@ public class ChatHelper {
 
 	public boolean isMuted(@NonNull ChatMessage message) {
 
+		if (isTwitchMessage(message) && !config.twitchChatEnabled()) {
+			return true;
+		}
+
 		ChatType chatType = getChatType(message);
 		EntityID eid = getEntityID(message);
 
@@ -311,9 +315,17 @@ public class ChatHelper {
 
 	@NonNull
 	public String standardizeChatMessageText(@NonNull ChatMessage message) {
-		String text = renderReplacements(message.getMessage());
+		String text = message.getMessage();
+		if (isTwitchMessage(message) && text.startsWith("<colNORMAL>")) {
+			text = text.replaceFirst("^<colNORMAL>", "");
+		}
+		text = renderReplacements(text);
 		text = Texts.renderLargeNumbers(text);
 		return text;
+	}
+
+	private static boolean isTwitchMessage(@NonNull ChatMessage message) {
+		return "Twitch".equals(message.getSender());
 	}
 
 	@NonNull


### PR DESCRIPTION
## Summary
- New `twitchChatEnabled` toggle (TTS Options → Twitch chat plugin, default **off**).
- `ChatHelper.isMuted` now blocks any `ChatMessage` whose `sender` is `\"Twitch\"` when the toggle is off.
- Twitch messages have their leading `<colNORMAL>` prefix stripped in `standardizeChatMessageText` so it isn't read out.

Refs upstream commit `d92bdb7` on master. Adapted to 1.3.0 by keeping the existing `ChatType.OtherPlayers` routing instead of introducing `RemotePlayers/LocalPlayers` (that's a separate, larger refactor).

## Test plan
- [ ] Install the RuneLite Twitch plugin and connect a channel.
- [ ] With this plugin's `Twitch chat plugin` toggle off (default): Twitch chat messages are not voiced.
- [ ] Toggle on: Twitch chat messages are voiced without the `<colNORMAL>` prefix.
- [ ] Regular FRIENDSCHAT messages (non-Twitch sender) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)