### PR TITLE
Fix numbers with commas in system messages

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -39,6 +39,9 @@ Intergrated with [Spam Filter](https://runelite.net/plugin-hub/show/spamfilter) 
 ---
 # Changelog
 
+## 1.3.0
+- Fixed numbers with commas in system messages not being read correctly
+
 ## 1.2.6
 - Updated Menu event handler to work with the latest update affecting submenus
 

--- a/src/main/java/dev/phyce/naturalspeech/SpeechEventHandler.java
+++ b/src/main/java/dev/phyce/naturalspeech/SpeechEventHandler.java
@@ -107,6 +107,7 @@ public class SpeechEventHandler {
 			return;
 		}
 
+		text = TextUtil.removeNumericCommas(text);
 		textToSpeech.speak(voiceId, text, distance, username);
 	}
 

--- a/src/main/java/dev/phyce/naturalspeech/utils/TextUtil.java
+++ b/src/main/java/dev/phyce/naturalspeech/utils/TextUtil.java
@@ -94,6 +94,17 @@ public final class TextUtil {
 		return patternAnyAlphaNumericChar.matcher(text).matches();
 	}
 
+	private static final Pattern NUMERIC_COMMA_PATTERN = Pattern.compile("\\d{1,3}(,\\d{3})+");
+	public static String removeNumericCommas(String input) {
+		Matcher matcher = NUMERIC_COMMA_PATTERN.matcher(input);
+		StringBuilder result = new StringBuilder();
+		while (matcher.find()) {
+			matcher.appendReplacement(result, matcher.group().replace(",", ""));
+		}
+		matcher.appendTail(result);
+		return result.toString();
+	}
+
 	public static String escape(String text) {
 		return text.replace("\\", "\\\\")
 			.replace("\"", "\\\"")


### PR DESCRIPTION
## Summary

- Add `TextUtil.removeNumericCommas` that strips thousand-separator commas from runs of digits (e.g. `1,000,000` → `1000000`).
- Call it in `SpeechEventHandler.onChatMessage` for **all three** voice paths — system, inner (local player + examines + trade requests), and other-player — so amounts spoken in player chat (`"selling for 1,234,567"`) get voiced as the number, not as a sequence broken up by commas.

The regex `\d{1,3}(,\d{3})+` matches the full comma-separated number in one greedy pass and strips every comma in the matched span, so arbitrary lengths work: `1,000`, `1,000,000`, `1,000,000,000,000,000,000,000` all collapse correctly. Decimals (`1,000.50` → `1000.50`) and trailing text (`1,234 gp` → `1234 gp`) are preserved.

## Relationship to PR #49 (numerical abbreviations)

- PR #49 owns k/m/b/t expansion only; PR #39 owns comma stripping only. Functionality is intentionally split between the two helpers.
- Intended call-site order is `removeNumericCommas` → `renderLargeNumbers`, so input like `"1,000k"` collapses to `"1000k"` then to `"1000 thousand"`.
- Whichever PR lands first: when the second one merges, expect a trivial conflict in the three `SpeechEventHandler` text-pipeline branches; resolve by keeping both calls with `removeNumericCommas` first.

## Test plan

- [ ] System message: `"Your bank value has increased by 1,234,567 coins"` is voiced as the full number.
- [ ] Public chat: another player typing `"got it for 1,000,000"` is voiced as the full number.
- [ ] Examine: an item examine containing `"This sells for around 1,234,567"` is voiced as the full number.
- [ ] Larger values: `1,000,000,000` → "one billion" (after PR #49 lands) or "1000000000" (PR #39 only).
- [ ] Decimal values: `1,000.50` → "1000.50".
- [ ] Trailing text: `1,234 gp` → "1234 gp".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

On behalf of @phyce