### PR TITLE
Gate CLAN_MESSAGE / CLAN_GUEST_MESSAGE on their channel toggle

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -41,6 +41,7 @@ Intergrated with [Spam Filter](https://runelite.net/plugin-hub/show/spamfilter) 
 
 ## 1.3.0
 - Fixed numbers with commas in system messages not being read correctly
+- Clan / clan guest system messages now also respect the matching channel toggle
 
 ## 1.2.6
 - Updated Menu event handler to work with the latest update affecting submenus

--- a/src/main/java/dev/phyce/naturalspeech/SpeechEventHandler.java
+++ b/src/main/java/dev/phyce/naturalspeech/SpeechEventHandler.java
@@ -234,6 +234,7 @@ public class SpeechEventHandler {
 			case BROADCAST:
 			case IGNORENOTIFICATION:
 			case CLAN_MESSAGE:
+			case CLAN_GUEST_MESSAGE:
 			case CONSOLE:
 			case TRADE:
 			case PLAYERRELATED:
@@ -358,6 +359,14 @@ public class SpeechEventHandler {
 			case WELCOME:
 			case GAMEMESSAGE:
 			case CONSOLE:
+				if (!config.systemMesagesEnabled()) return true;
+				break;
+			case CLAN_MESSAGE:
+				if (!config.clanChatEnabled()) return true;
+				if (!config.systemMesagesEnabled()) return true;
+				break;
+			case CLAN_GUEST_MESSAGE:
+				if (!config.clanGuestChatEnabled()) return true;
 				if (!config.systemMesagesEnabled()) return true;
 				break;
 			case TRADEREQ:


### PR DESCRIPTION
## Summary
- `CLAN_MESSAGE` and `CLAN_GUEST_MESSAGE` (clan login/logout/system notifications) were not gated anywhere in `isMessageTypeDisabledInConfig`. Disabling Clan / Clan-guest chat did not stop these notifications from being voiced.
- Each clan-system bucket now requires both its own channel toggle and the global system-messages toggle to be enabled before being voiced.

## Test plan
- [ ] With `Clan chat` disabled, in-clan login/logout system notifications should not be voiced.
- [ ] With `Clan chat` enabled but `System messages` disabled, the same notifications should remain silent.
- [ ] With both enabled, they should be voiced normally.
- [ ] Verify the same behaviour for `Clan guest chat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

On behalf of @phyce