### PR TITLE
Apply Mute Grand Exchange to NPC overhead text as well

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -39,6 +39,9 @@ Intergrated with [Spam Filter](https://runelite.net/plugin-hub/show/spamfilter) 
 ---
 # Changelog
 
+## 1.3.0
+- `Mute Grand Exchange` now also mutes NPC overhead text in the GE
+
 ## 1.2.6
 - Updated Menu event handler to work with the latest update affecting submenus
 

--- a/src/main/java/dev/phyce/naturalspeech/SpeechEventHandler.java
+++ b/src/main/java/dev/phyce/naturalspeech/SpeechEventHandler.java
@@ -176,6 +176,7 @@ public class SpeechEventHandler {
 
 		if (event.getActor() instanceof NPC) {
 			if (!config.npcOverheadEnabled()) return;
+			if (isAreaDisabled()) return;
 			NPC npc = (NPC) event.getActor();
 			if (!muteManager.isNpcAllowed(npc)) return;
 


### PR DESCRIPTION
## Summary
- `OverheadTextChanged` for NPCs bypassed the area-disabled check, so toggling `Mute Grand Exchange` silenced GE NPC chat-messages but not their overhead text.
- Add the same `isAreaDisabled()` gate that the chat-message path already uses.

## Test plan
- [ ] Enable `Mute Grand Exchange`, stand in GE — NPC overhead text (shopkeeper yells, etc.) should be silent.
- [ ] Walk outside GE with the setting on — NPC overhead text should be audible again.
- [ ] Disable `Mute Grand Exchange`, stand in GE — NPC overhead text should be audible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

On behalf of @phyce