### PR TITLE
Replace deprecated client.getPlayers() with WorldView

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -39,6 +39,9 @@ Intergrated with [Spam Filter](https://runelite.net/plugin-hub/show/spamfilter) 
 ---
 # Changelog
 
+## 1.3.0
+- Replaced deprecated `client.getPlayers()` usage with the world view API
+
 ## 1.2.6
 - Updated Menu event handler to work with the latest update affecting submenus
 

--- a/src/main/java/dev/phyce/naturalspeech/SpeechEventHandler.java
+++ b/src/main/java/dev/phyce/naturalspeech/SpeechEventHandler.java
@@ -310,7 +310,8 @@ public class SpeechEventHandler {
 		Player localPlayer = client.getLocalPlayer();
 		if (localPlayer == null) return false;
 
-		int count = (int) client.getPlayers().stream()
+		long count = java.util.stream.StreamSupport.stream(
+				client.getTopLevelWorldView().players().spliterator(), false)
 			.filter(player -> player != localPlayer) // Exclude the local player themselves
 			.filter(player -> player.getWorldLocation().distanceTo(localPlayer.getWorldLocation()) <=
 				15) // For example, within 15 tiles


### PR DESCRIPTION
## Summary
- `client.getPlayers()` in `SpeechEventHandler.isTooCrowded()` is deprecated; route through `client.getTopLevelWorldView().players()` so the plugin keeps working as RuneLite removes the old accessor.
- (The other usage, `client.getCachedPlayers()`, was already replaced in `61f9d13`.)

## Test plan
- [ ] Plugin starts without errors.
- [ ] `Mute crowds` (`muteCrowds`) threshold behaviour is unchanged when surrounded by other players.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

On behalf of @phyce