### PR TITLE
Add Discord help link to main settings panel

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -39,6 +39,9 @@ Intergrated with [Spam Filter](https://runelite.net/plugin-hub/show/spamfilter) 
 ---
 # Changelog
 
+## 1.3.0
+- Added a Discord help link to the main settings panel
+
 ## 1.2.6
 - Updated Menu event handler to work with the latest update affecting submenus
 

--- a/src/main/java/dev/phyce/naturalspeech/ui/panels/MainSettingsPanel.java
+++ b/src/main/java/dev/phyce/naturalspeech/ui/panels/MainSettingsPanel.java
@@ -197,6 +197,23 @@ public class MainSettingsPanel extends PluginPanel {
 		instructionsLink.setBorder(new EmptyBorder(0, 0, 5, 0));
 		mainContentPanel.add(instructionsLink);
 
+		// Discord Link
+		JLabel discordLink =
+			new JLabel("<html>Ask for help on our <a style=\"color:#7289da\" href='#'>Discord</a></html>", JLabel.CENTER);
+		discordLink.setCursor(new Cursor(Cursor.HAND_CURSOR));
+		discordLink.addMouseListener(new MouseAdapter() {
+			@Override
+			public void mouseClicked(MouseEvent e) {
+				try {
+					LinkBrowser.browse("https://discord.gg/smhQRcyXVU");
+				} catch (Exception ex) {
+					log.error("Error opening Discord link.", ex);
+				}
+			}
+		});
+		discordLink.setBorder(new EmptyBorder(0, 0, 5, 0));
+		mainContentPanel.add(discordLink);
+
 	}
 
 	public void buildVoiceRepositorySegment() {

--- a/src/main/java/dev/phyce/naturalspeech/ui/panels/MainSettingsPanel.java
+++ b/src/main/java/dev/phyce/naturalspeech/ui/panels/MainSettingsPanel.java
@@ -199,7 +199,7 @@ public class MainSettingsPanel extends PluginPanel {
 
 		// Discord Link
 		JLabel discordLink =
-			new JLabel("<html>Ask for help on our <a style=\"color:#7289da\" href='#'>Discord</a></html>", JLabel.CENTER);
+			new JLabel("<html>Need help? Ask on our <a style="color:#7289da" href='#'>Discord</a></html>", JLabel.CENTER);
 		discordLink.setCursor(new Cursor(Cursor.HAND_CURSOR));
 		discordLink.addMouseListener(new MouseAdapter() {
 			@Override


### PR DESCRIPTION
## Summary
- Adds a clickable "Ask for help on our Discord" link below the existing instructions link, opening `https://discord.gg/smhQRcyXVU` via `LinkBrowser`.

## Test plan
- [ ] Open the Natural Speech side panel — Discord link appears below the instructions link.
- [ ] Click the Discord link — default browser opens the invite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

On behalf of @phyce