### PR TITLE
Independent NPC / Player dialog toggles (issue #23)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -46,7 +46,7 @@ Intergrated with [Spam Filter](https://runelite.net/plugin-hub/show/spamfilter) 
 - `Global NPC voice` now properly overrides per-NPC voice settings
 - Fixed numbers with commas in system messages not being read correctly
 - Clan / clan guest system messages now also respect the matching channel toggle
-- Renamed the `Dialogs` toggle to `NPC dialogs` and added an independent `Player dialogs` toggle (issue #23)
+- Renamed the `Dialogs` toggle to `NPC dialogs` and added `Player dialogs` toggle
 
 ## 1.2.6
 - Updated Menu event handler to work with the latest update affecting submenus

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -46,6 +46,7 @@ Intergrated with [Spam Filter](https://runelite.net/plugin-hub/show/spamfilter) 
 - `Global NPC voice` now properly overrides per-NPC voice settings
 - Fixed numbers with commas in system messages not being read correctly
 - Clan / clan guest system messages now also respect the matching channel toggle
+- Renamed the `Dialogs` toggle to `NPC dialogs` and added an independent `Player dialogs` toggle (issue #23)
 
 ## 1.2.6
 - Updated Menu event handler to work with the latest update affecting submenus

--- a/src/main/java/dev/phyce/naturalspeech/SpeechEventHandler.java
+++ b/src/main/java/dev/phyce/naturalspeech/SpeechEventHandler.java
@@ -113,8 +113,8 @@ public class SpeechEventHandler {
 
 	@Subscribe(priority=-100)
 	private void onWidgetLoaded(WidgetLoaded event) {
-		if(!config.dialogEnabled())return;
 		if (event.getGroupId() == InterfaceID.DIALOG_PLAYER) {
+			if (!config.playerDialogEnabled()) return;
 			// InvokeAtTickEnd to wait until the text has loaded in
 			clientThread.invokeAtTickEnd(() -> {
 				Widget textWidget = client.getWidget(ComponentID.DIALOG_PLAYER_TEXT);
@@ -133,6 +133,7 @@ public class SpeechEventHandler {
 				textToSpeech.speak(voiceID, text, 0, MagicUsernames.LOCAL_USER);
 			});
 		} else if (event.getGroupId() == InterfaceID.DIALOG_NPC) {
+			if (!config.npcDialogEnabled()) return;
 			// InvokeAtTickEnd to wait until the text has loaded in
 			clientThread.invokeAtTickEnd(() -> {
 				Widget textWidget = client.getWidget(ComponentID.DIALOG_NPC_TEXT);

--- a/src/main/java/dev/phyce/naturalspeech/configs/NaturalSpeechConfig.java
+++ b/src/main/java/dev/phyce/naturalspeech/configs/NaturalSpeechConfig.java
@@ -29,6 +29,7 @@ public interface NaturalSpeechConfig extends Config {
 		public static final String EXAMINE_CHAT = "examineChat";
 		public static final String NPC_OVERHEAD = "npcOverhead";
 		public static final String DIALOG = "dialog";
+		public static final String PLAYER_DIALOG = "playerDialog";
 		public static final String REQUESTS = "requests";
 		public static final String SYSTEM_MESSAGES = "systemMessages";
 		public static final String MUTE_GRAND_EXCHANGE = "muteGrandExchange";
@@ -254,12 +255,23 @@ public interface NaturalSpeechConfig extends Config {
 
 	@ConfigItem(
 		keyName=ConfigKeys.DIALOG,
-		name="Dialogs",
-		description="Enable text-to-speech to dialog text.",
+		name="NPC dialogs",
+		description="Enable text-to-speech for NPC dialog text.",
 		section=ttsOptionsSection,
 		position=10
 	)
-	default boolean dialogEnabled() {
+	default boolean npcDialogEnabled() {
+		return true;
+	}
+
+	@ConfigItem(
+		keyName=ConfigKeys.PLAYER_DIALOG,
+		name="Player dialogs",
+		description="Enable text-to-speech for your own dialog lines.",
+		section=ttsOptionsSection,
+		position=11
+	)
+	default boolean playerDialogEnabled() {
 		return true;
 	}
 
@@ -268,7 +280,7 @@ public interface NaturalSpeechConfig extends Config {
 		name="Trade/Challenge requests",
 		description="Enable text-to-speech to trade and challenge requests.",
 		section=ttsOptionsSection,
-		position=11
+		position=12
 	)
 	default boolean requestsEnabled() {
 		return false;
@@ -279,7 +291,7 @@ public interface NaturalSpeechConfig extends Config {
 		name="System messages",
 		description="Generate text-to-speech to game's messages",
 		section=ttsOptionsSection,
-		position=12
+		position=13
 	)
 	default boolean systemMesagesEnabled() {
 		return true;


### PR DESCRIPTION
## Summary

Two changes:

1. **Independent gates.** The original `Dialogs` toggle gated both branches at the top of `onWidgetLoaded`, so turning it off muted everything regardless of the newer `Player dialogs` toggle. Drop the outer gate; each branch now consults only its own option.
2. **Renamed `Dialogs` → `NPC dialogs`** — that's all the original toggle actually controls now. The config key stays `dialog` so existing user settings carry over; only the display label and Java accessor (`dialogEnabled()` → `npcDialogEnabled()`) change.

### Truth table

| `npcDialog` | `playerDialog` | Result |
|---|---|---|
| on | on | both speak |
| on | off | only NPC speaks |
| off | on | only player speaks *(was: nothing)* |
| off | off | nothing speaks |

Closes #23.

## Test plan

- [ ] Both on (default) → both NPC and your own dialog speak.
- [ ] NPC off, Player on → spam-clicking through your own quest dialog speaks, NPC stays silent.
- [ ] NPC on, Player off → NPC speaks, your own lines stay silent (the original use case).
- [ ] Both off → quest dialog is fully silent.
- [ ] Existing users who had `dialog=false` set in 1.2.6 → their setting still applies (only NPC dialog is silenced; player dialog defaults on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

On behalf of @phyce