### PR TITLE
Add RuneLite Twitch plugin integration

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -47,6 +47,7 @@ Intergrated with [Spam Filter](https://runelite.net/plugin-hub/show/spamfilter) 
 - Fixed numbers with commas in system messages not being read correctly
 - Clan / clan guest system messages now also respect the matching channel toggle
 - Renamed the `Dialogs` toggle to `NPC dialogs` and added `Player dialogs` toggle
+- Added optional integration with the RuneLite Twitch plugin (toggle in TTS Options)
 
 ## 1.2.6
 - Updated Menu event handler to work with the latest update affecting submenus

--- a/src/main/java/dev/phyce/naturalspeech/NaturalSpeechPlugin.java
+++ b/src/main/java/dev/phyce/naturalspeech/NaturalSpeechPlugin.java
@@ -144,6 +144,7 @@ public class NaturalSpeechPlugin extends Plugin {
 		updateConfigVoice(ConfigKeys.PERSONAL_VOICE, config.personalVoiceID());
 		updateConfigVoice(ConfigKeys.GLOBAL_NPC_VOICE, config.globalNpcVoice());
 		updateConfigVoice(ConfigKeys.SYSTEM_VOICE, config.systemVoice());
+		updateConfigVoice(ConfigKeys.TWITCH_VOICE, config.twitchVoice());
 
 		log.info("NaturalSpeech plugin has started");
 	}
@@ -218,6 +219,7 @@ public class NaturalSpeechPlugin extends Plugin {
 			case ConfigKeys.PERSONAL_VOICE:
 			case ConfigKeys.GLOBAL_NPC_VOICE:
 			case ConfigKeys.SYSTEM_VOICE:
+			case ConfigKeys.TWITCH_VOICE:
 				log.trace("Detected voice changes from config, loading in new voices");
 				updateConfigVoice(event.getKey(), event.getNewValue());
 				break;
@@ -259,6 +261,16 @@ public class NaturalSpeechPlugin extends Plugin {
 				else {
 					log.debug("Invalid voice for {}, resetting voices.", MagicUsernames.SYSTEM);
 					voiceManager.resetForUsername(MagicUsernames.SYSTEM);
+				}
+				break;
+			case ConfigKeys.TWITCH_VOICE:
+				if (voiceID != null) {
+					log.debug("Setting voice for {} to {}", MagicUsernames.TWITCH, voiceID);
+					voiceManager.setDefaultVoiceIDForUsername(MagicUsernames.TWITCH, voiceID);
+				}
+				else {
+					log.debug("Invalid voice for {}, resetting voices.", MagicUsernames.TWITCH);
+					voiceManager.resetForUsername(MagicUsernames.TWITCH);
 				}
 				break;
 		}

--- a/src/main/java/dev/phyce/naturalspeech/SpeechEventHandler.java
+++ b/src/main/java/dev/phyce/naturalspeech/SpeechEventHandler.java
@@ -72,9 +72,6 @@ public class SpeechEventHandler {
 
 		try {
 			if (isTwitchMessage(message)) {
-				// If twitchVoice is configured, route through the TWITCH magic
-				// username so all Twitch chat shares the override voice. Empty
-				// = keep per-chatter voices (existing behaviour).
 				if (!config.twitchVoice().isEmpty()) {
 					username = MagicUsernames.TWITCH;
 				}

--- a/src/main/java/dev/phyce/naturalspeech/SpeechEventHandler.java
+++ b/src/main/java/dev/phyce/naturalspeech/SpeechEventHandler.java
@@ -68,11 +68,26 @@ public class SpeechEventHandler {
 			.replace("<lt>", "<")
 			.replace("<gt>", ">");
 
-
 		if (isChatMessageMuted(message)) return;
 
 		try {
-			if (isChatInnerVoice(message)) {
+			if (isTwitchMessage(message)) {
+				// If twitchVoice is configured, route through the TWITCH magic
+				// username so all Twitch chat shares the override voice. Empty
+				// = keep per-chatter voices (existing behaviour).
+				if (!config.twitchVoice().isEmpty()) {
+					username = MagicUsernames.TWITCH;
+				}
+				distance = 0;
+				voiceId = voiceManager.getVoiceIDFromUsername(username);
+				if (text.startsWith("<colNORMAL>")) {
+					text = text.replaceFirst("^<colNORMAL>", "");
+				}
+				text = textToSpeech.expandShortenedPhrases(text);
+
+				log.debug("Twitch voice {} used for {}. ", voiceId, username);
+			}
+			else if (isChatInnerVoice(message)) {
 				username = MagicUsernames.LOCAL_USER;
 				distance = 0;
 				voiceId = voiceManager.getVoiceIDFromUsername(username);
@@ -252,10 +267,16 @@ public class SpeechEventHandler {
 		}
 	}
 
+	private static boolean isTwitchMessage(ChatMessage message) {
+		return "Twitch".equals(message.getSender());
+	}
+
 	public boolean isChatMessageMuted(ChatMessage message) {
 		if (message.getType() == ChatMessageType.AUTOTYPER) return true;
 		// dialog messages are handled in onWidgetLoad
 		if (message.getType() == ChatMessageType.DIALOG) return true;
+
+		if (isTwitchMessage(message) && !config.twitchChatEnabled()) return true;
 
 		// example: "::::::))))))" (no alpha numeric, muted)
 		if (!TextUtil.containAlphaNumeric(message.getMessage())) {
@@ -346,7 +367,10 @@ public class SpeechEventHandler {
 				if (!config.privateOutChatEnabled()) return true;
 				break;
 			case FRIENDSCHAT:
-				if (!config.friendsChatEnabled()) return true;
+				if (isTwitchMessage(message)) {
+					if (!config.twitchChatEnabled()) return true;
+				}
+				else if (!config.friendsChatEnabled()) return true;
 				break;
 			case CLAN_CHAT:
 				if (!config.clanChatEnabled()) return true;

--- a/src/main/java/dev/phyce/naturalspeech/configs/NaturalSpeechConfig.java
+++ b/src/main/java/dev/phyce/naturalspeech/configs/NaturalSpeechConfig.java
@@ -16,6 +16,7 @@ public interface NaturalSpeechConfig extends Config {
 		public static final String PERSONAL_VOICE = "personalVoice";
 		public static final String GLOBAL_NPC_VOICE = "globalNpcVoice";
 		public static final String SYSTEM_VOICE = "systemVoice";
+		public static final String TWITCH_VOICE = "twitchVoice";
 		public static final String AUTO_START = "autoStart";
 		public static final String DISTANCE_FADE = "distanceFade";
 		public static final String MASTER_VOLUME = "masterVolume";
@@ -32,6 +33,7 @@ public interface NaturalSpeechConfig extends Config {
 		public static final String PLAYER_DIALOG = "playerDialog";
 		public static final String REQUESTS = "requests";
 		public static final String SYSTEM_MESSAGES = "systemMessages";
+		public static final String TWITCH_CHAT = "twitchChat";
 		public static final String MUTE_GRAND_EXCHANGE = "muteGrandExchange";
 		public static final String MUTE_SELF = "muteSelf";
 		public static final String MUTE_OTHERS = "muteOthers";
@@ -87,6 +89,17 @@ public interface NaturalSpeechConfig extends Config {
 
 	@ConfigItem(
 		position=4,
+		keyName=ConfigKeys.TWITCH_VOICE,
+		name="Twitch chat voice",
+		description="Choose one of the voices for Twitch chat (overrides per-chatter voices). Leave empty to keep one voice per Twitch chatter.",
+		section=generalSettingsSection
+	)
+	default String twitchVoice() {
+		return "";
+	}
+
+	@ConfigItem(
+		position=5,
 		keyName=ConfigKeys.AUTO_START,
 		name="Autostart the TTS engine",
 		description="If executable and voice models available, autostart the TTS engine when the plugin loads.",
@@ -95,7 +108,7 @@ public interface NaturalSpeechConfig extends Config {
 	default boolean autoStart() {return true;}
 
 	@ConfigItem(
-		position=5,
+		position=6,
 		keyName=ConfigKeys.DISTANCE_FADE,
 		name="Fade distant sound",
 		description="Players standing further away will sound quieter.",
@@ -107,7 +120,7 @@ public interface NaturalSpeechConfig extends Config {
 	}
 
 	@ConfigItem(
-		position=6,
+		position=7,
 		keyName=ConfigKeys.MASTER_VOLUME,
 		name="Master volume control",
 		description="Volume percentage",
@@ -120,7 +133,7 @@ public interface NaturalSpeechConfig extends Config {
 	}
 
 	@ConfigItem(
-		position=7,
+		position=8,
 		keyName=ConfigKeys.HOLD_SHIFT_RIGHT_CLICK_MENU,
 		name="Hold shift for right-click menu",
 		description="Only show the right-click menu when holding shift.",
@@ -295,6 +308,17 @@ public interface NaturalSpeechConfig extends Config {
 	)
 	default boolean systemMesagesEnabled() {
 		return true;
+	}
+
+	@ConfigItem(
+		keyName=ConfigKeys.TWITCH_CHAT,
+		name="Twitch chat plugin",
+		description="Generate text-to-speech of messages received via the RuneLite Twitch plugin.",
+		section=ttsOptionsSection,
+		position=13
+	)
+	default boolean twitchChatEnabled() {
+		return false;
 	}
 	//</editor-fold>
 

--- a/src/main/java/dev/phyce/naturalspeech/configs/NaturalSpeechConfig.java
+++ b/src/main/java/dev/phyce/naturalspeech/configs/NaturalSpeechConfig.java
@@ -91,7 +91,7 @@ public interface NaturalSpeechConfig extends Config {
 		position=4,
 		keyName=ConfigKeys.TWITCH_VOICE,
 		name="Twitch chat voice",
-		description="Choose one of the voices for Twitch chat (overrides per-chatter voices). Leave empty to keep one voice per Twitch chatter.",
+		description="Choose one of the voices for Twitch chat, example: libritts:0",
 		section=generalSettingsSection
 	)
 	default String twitchVoice() {

--- a/src/main/java/dev/phyce/naturalspeech/tts/MagicUsernames.java
+++ b/src/main/java/dev/phyce/naturalspeech/tts/MagicUsernames.java
@@ -4,4 +4,5 @@ public final class MagicUsernames {
 	public static final String SYSTEM = "&system";
 	public static final String GLOBAL_NPC = "&globalnpc";
 	public static final String LOCAL_USER = "&localuser";
+	public static final String TWITCH = "&twitch";
 }


### PR DESCRIPTION
## Summary

Integrate the RuneLite Twitch plugin with rl-natural-speech so Twitch chat messages get spoken.

### What this PR adds

- **`Twitch chat plugin` toggle** (Speech Generation section, default off) — opt-in for whether Twitch messages speak at all.
- **`Twitch chat voice` input** (General Settings, default empty) — optional voice ID override. Empty = each Twitch chatter keeps their own per-username voice (same as the existing per-player voice behaviour). Set (e.g. `libritts:5`) = all Twitch chatters speak through that single voice. Mirrors the existing `globalNpcVoice` / `systemVoice` override pattern.
- **`isTwitchMessage`** check inside the existing if/else cascade in `onChatMessage`. Detection is `"Twitch".equals(message.getSender())` (the sender string set by `TwitchPlugin.java` upstream — verified against `runelite/runelite-client/src/main/java/net/runelite/client/plugins/twitch/TwitchPlugin.java:172`).
- **`<colNORMAL>` strip** for Twitch messages only. The Twitch plugin wraps message bodies with `<colNORMAL>` via `ChatMessageBuilder` (`ChatMessageBuilder.java:37` → `"<col" + ChatColorType.NORMAL.name() + ">"`); without stripping, Piper would speak "colNORMAL ..." aloud.
- **`MagicUsernames.TWITCH`** constant + matching plumbing in `NaturalSpeechPlugin.onConfigChanged` / `updateConfigVoice` / startup. Voice override is registered the same way `SYSTEM` / `GLOBAL_NPC` already are.

### What this PR does *not* do

- It does not strip game-injected tags in general — for Twitch's case the per-message `<colNORMAL>` strip is targeted; a broader sanitation discussion lives in #63.
- The `twitchChatEnabled` check is gated in both `isChatMessageMuted` (early) and `isMessageTypeDisabledInConfig` (FRIENDSCHAT case). Redundant; left in for explicit-intent reasons. Can drop one in a follow-up if preferred.

## Test plan

- [ ] Install the Twitch plugin, configure it, join a channel. Enable `Twitch chat plugin`. Messages from chatters speak through individual voices (one per username).
- [ ] Set `Twitch chat voice` to `libritts:5`. All Twitch chat now speaks through `libritts:5`. Local + clan / friends chat unaffected.
- [ ] Clear `Twitch chat voice`. Per-chatter voices come back.
- [ ] Disable `Twitch chat plugin`. Twitch messages stop speaking; regular friends chat still does.
- [ ] `<colNORMAL>` is never spoken aloud regardless of the toggle / override state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

On behalf of @phyce