### PR TITLE
Apply Mute crowds to NPC overhead text

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -39,6 +39,9 @@ Intergrated with [Spam Filter](https://runelite.net/plugin-hub/show/spamfilter) 
 ---
 # Changelog
 
+## 1.3.0
+- `Mute crowds` now also silences NPC overhead text in crowded areas
+
 ## 1.2.6
 - Updated Menu event handler to work with the latest update affecting submenus
 

--- a/src/main/java/dev/phyce/naturalspeech/SpeechEventHandler.java
+++ b/src/main/java/dev/phyce/naturalspeech/SpeechEventHandler.java
@@ -176,6 +176,7 @@ public class SpeechEventHandler {
 
 		if (event.getActor() instanceof NPC) {
 			if (!config.npcOverheadEnabled()) return;
+			if (isTooCrowded()) return;
 			NPC npc = (NPC) event.getActor();
 			if (!muteManager.isNpcAllowed(npc)) return;
 


### PR DESCRIPTION
## Summary
- NPC overhead voicing did not honour the `Mute crowds` threshold; only chat messages did. Apply `isTooCrowded()` to `SpeechEventHandler.onOverheadTextChanged` so crowded areas (tutorial NPCs, GE shouters, etc.) go quiet too.

## Test plan
- [ ] With `Mute crowds` set to e.g. 5, stand among more than 5 players where NPCs shout — overhead text should be silent.
- [ ] Step away from the crowd — overhead text returns.
- [ ] `Mute crowds = 0` (off): NPC overhead works as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

On behalf of @phyce