### PR TITLE
Expand numerical abbreviations (k, m, b, t)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -39,6 +39,9 @@ Intergrated with [Spam Filter](https://runelite.net/plugin-hub/show/spamfilter) 
 ---
 # Changelog
 
+## 1.3.0
+- Numerical abbreviations (k, m, b, t) are now expanded so "5k" reads as "five thousand"
+
 ## 1.2.6
 - Updated Menu event handler to work with the latest update affecting submenus
 

--- a/src/main/java/dev/phyce/naturalspeech/SpeechEventHandler.java
+++ b/src/main/java/dev/phyce/naturalspeech/SpeechEventHandler.java
@@ -77,6 +77,7 @@ public class SpeechEventHandler {
 				distance = 0;
 				voiceId = voiceManager.getVoiceIDFromUsername(username);
 				text = textToSpeech.expandShortenedPhrases(text);
+				text = TextUtil.renderLargeNumbers(text);
 
 				log.debug("Inner voice {} used for {} for {}. ", voiceId, message.getType(), username);
 			}
@@ -84,6 +85,7 @@ public class SpeechEventHandler {
 				distance = config.distanceFadeEnabled()? getDistance(username) : 0;
 				voiceId = voiceManager.getVoiceIDFromUsername(username);
 				text = textToSpeech.expandShortenedPhrases(text);
+				text = TextUtil.renderLargeNumbers(text);
 
 				log.debug("Player voice {} used for {} for {}. ", voiceId, message.getType(), username);
 			}
@@ -92,6 +94,7 @@ public class SpeechEventHandler {
 				distance = 0;
 				text = Text.removeTags(text);
 				text = Text.standardize(text);
+				text = TextUtil.renderLargeNumbers(text);
 				voiceId = voiceManager.getVoiceIDFromUsername(username);
 
 				log.debug("System voice {} used for {} for {}. ", voiceId, message.getType(), username);

--- a/src/main/java/dev/phyce/naturalspeech/utils/TextUtil.java
+++ b/src/main/java/dev/phyce/naturalspeech/utils/TextUtil.java
@@ -96,17 +96,15 @@ public final class TextUtil {
 
 	/**
 	 * Expand common numeric shorthand so TTS reads it as words:
-	 *   1,000        -> 1000      (single comma stripped)
 	 *   5k           -> 5 thousand
 	 *   2.5m         -> 2.5 million
 	 *   1b           -> 1 billion
 	 *   1t           -> 1 trillion
-	 * Multi-comma values like 1,000,000 should be passed through
-	 * removeNumericCommas first.
+	 * Comma stripping is intentionally not handled here — use
+	 * {@link #removeNumericCommas(String)} for that. Run it first if your
+	 * input may contain numbers like "1,000k".
 	 */
 	public static String renderLargeNumbers(String text) {
-		text = text.replaceAll("(?i)(\\d{1,3})(,)(\\d{3})", "$1$3");
-		text = text.replaceAll("(?i)(\\d)(,)(\\d{3})(\\.\\d+)?", "$1$3$4");
 		text = text.replaceAll("(?i)(\\d+)\\s?k\\b", "$1 thousand");
 		text = text.replaceAll("(?i)(\\d+)\\s?m\\b", "$1 million");
 		text = text.replaceAll("(?i)(\\d+)\\s?b\\b", "$1 billion");

--- a/src/main/java/dev/phyce/naturalspeech/utils/TextUtil.java
+++ b/src/main/java/dev/phyce/naturalspeech/utils/TextUtil.java
@@ -94,6 +94,26 @@ public final class TextUtil {
 		return patternAnyAlphaNumericChar.matcher(text).matches();
 	}
 
+	/**
+	 * Expand common numeric shorthand so TTS reads it as words:
+	 *   1,000        -> 1000      (single comma stripped)
+	 *   5k           -> 5 thousand
+	 *   2.5m         -> 2.5 million
+	 *   1b           -> 1 billion
+	 *   1t           -> 1 trillion
+	 * Multi-comma values like 1,000,000 should be passed through
+	 * removeNumericCommas first.
+	 */
+	public static String renderLargeNumbers(String text) {
+		text = text.replaceAll("(?i)(\\d{1,3})(,)(\\d{3})", "$1$3");
+		text = text.replaceAll("(?i)(\\d)(,)(\\d{3})(\\.\\d+)?", "$1$3$4");
+		text = text.replaceAll("(?i)(\\d+)\\s?k\\b", "$1 thousand");
+		text = text.replaceAll("(?i)(\\d+)\\s?m\\b", "$1 million");
+		text = text.replaceAll("(?i)(\\d+)\\s?b\\b", "$1 billion");
+		text = text.replaceAll("(?i)(\\d+)\\s?t\\b", "$1 trillion");
+		return text;
+	}
+
 	public static String escape(String text) {
 		return text.replace("\\", "\\\\")
 			.replace("\"", "\\\"")


### PR DESCRIPTION
## Summary

- Add `TextUtil.renderLargeNumbers` that expands `k/m/b/t` suffixes to their full words (`5k` → `5 thousand`, `2.5m` → `2.5 million`, etc.).
- Apply it on all three voice paths in `SpeechEventHandler.onChatMessage` (inner / other-player / system), after `expandShortenedPhrases` so user replacements still win.

## Relationship to PR #39 (comma stripping)

- `renderLargeNumbers` deliberately does **not** handle commas — that lives in `TextUtil.removeNumericCommas` (PR #39). Functionality is intentionally split so each helper does one thing.
- Intended call-site order is `removeNumericCommas` → `renderLargeNumbers`, so input like `"1,000k"` collapses to `"1000k"` then to `"1000 thousand"`.
- Whichever PR lands first: when the second one merges, expect a trivial conflict in the three `SpeechEventHandler` text-pipeline branches; resolve by keeping both calls with `removeNumericCommas` first.

## Test plan

- [ ] `"I dropped 5k"` → "I dropped 5 thousand".
- [ ] `"2.5m gp"` → "2.5 million gp".
- [ ] `"1b xp"` → "1 billion xp".
- [ ] System drop message containing `1,000,000` reads as "one million" once PR #39 has landed and stripped the commas first.
- [ ] Words containing letters that happen to end in k/m/b/t after digits — verify the `\b` word boundary keeps them sensible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

On behalf of @phyce