### PR TITLE
Add 'Friends only' mode

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -40,7 +40,7 @@ Intergrated with [Spam Filter](https://runelite.net/plugin-hub/show/spamfilter) 
 # Changelog
 
 ## 1.3.0
-- Added `Friends only` mode to mute everyone except players on your friends list
+- Added `Friends only` mode
 
 ## 1.2.6
 - Updated Menu event handler to work with the latest update affecting submenus

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -39,6 +39,9 @@ Intergrated with [Spam Filter](https://runelite.net/plugin-hub/show/spamfilter) 
 ---
 # Changelog
 
+## 1.3.0
+- Added `Friends only` mode to mute everyone except players on your friends list
+
 ## 1.2.6
 - Updated Menu event handler to work with the latest update affecting submenus
 

--- a/src/main/java/dev/phyce/naturalspeech/SpeechEventHandler.java
+++ b/src/main/java/dev/phyce/naturalspeech/SpeechEventHandler.java
@@ -248,10 +248,20 @@ public class SpeechEventHandler {
 		}
 	}
 
+	private boolean isFriend(ChatMessage message) {
+		String name = Text.standardize(message.getName());
+		return !name.isEmpty() && client.isFriended(name, false);
+	}
+
 	public boolean isChatMessageMuted(ChatMessage message) {
 		if (message.getType() == ChatMessageType.AUTOTYPER) return true;
 		// dialog messages are handled in onWidgetLoad
 		if (message.getType() == ChatMessageType.DIALOG) return true;
+
+		if (config.friendsOnlyMode() && isChatOtherPlayerVoice(message) && !isFriend(message)) {
+			log.trace("Muting message. Friends-only mode and sender is not a friend. Message:{}", message.getMessage());
+			return true;
+		}
 
 		// example: "::::::))))))" (no alpha numeric, muted)
 		if (!TextUtil.containAlphaNumeric(message.getMessage())) {

--- a/src/main/java/dev/phyce/naturalspeech/configs/NaturalSpeechConfig.java
+++ b/src/main/java/dev/phyce/naturalspeech/configs/NaturalSpeechConfig.java
@@ -310,7 +310,7 @@ public interface NaturalSpeechConfig extends Config {
 	@ConfigItem(
 		position=1,
 		keyName=ConfigKeys.FRIENDS_ONLY_MODE,
-		name="Friends only",
+		name="Friends only mode",
 		description="Only generate text-to-speech for friends.",
 		section=muteOptionsSection
 	)

--- a/src/main/java/dev/phyce/naturalspeech/configs/NaturalSpeechConfig.java
+++ b/src/main/java/dev/phyce/naturalspeech/configs/NaturalSpeechConfig.java
@@ -26,6 +26,7 @@ public interface NaturalSpeechConfig extends Config {
 		public static final String FRIENDS_CHAT = "friendsChat";
 		public static final String CLAN_CHAT = "clanChat";
 		public static final String CLAN_GUEST_CHAT = "clanGuestChat";
+		public static final String FRIENDS_ONLY_MODE = "friendsOnlyMode";
 		public static final String EXAMINE_CHAT = "examineChat";
 		public static final String NPC_OVERHEAD = "npcOverhead";
 		public static final String DIALOG = "dialog";
@@ -303,6 +304,17 @@ public interface NaturalSpeechConfig extends Config {
 
 	)
 	default boolean muteOthers() {
+		return false;
+	}
+
+	@ConfigItem(
+		position=1,
+		keyName=ConfigKeys.FRIENDS_ONLY_MODE,
+		name="Friends only",
+		description="Only generate text-to-speech for friends.",
+		section=muteOptionsSection
+	)
+	default boolean friendsOnlyMode() {
 		return false;
 	}
 


### PR DESCRIPTION
## Summary
- New `friendsOnlyMode` config option under Mute Options (default off).
- When on, other-player chat (public / private / clan / clan guest / friends chat / GIM chat) from a non-friend is muted via `isChatMessageMuted`.
- Uses `client.isFriended(name, false)` for the friend lookup.
- Inner voice (own chat), system voice, NPC overhead, dialog are unaffected.

## Test plan
- [ ] Enable `Friends only` — chat from random nearby players is silent.
- [ ] Chat from someone on your friends list is voiced.
- [ ] Your own chat is voiced regardless.
- [ ] System messages (welcome, login/logout, GE notifications) unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

On behalf of @phyce