### PR TITLE
Add 'Serialize chat playback' toggle (issue #22)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -39,6 +39,9 @@ Intergrated with [Spam Filter](https://runelite.net/plugin-hub/show/spamfilter) 
 ---
 # Changelog
 
+## 1.3.0
+- Added `Serialize chat playback` toggle so chat messages play in turn instead of overlapping
+
 ## 1.2.6
 - Updated Menu event handler to work with the latest update affecting submenus
 

--- a/src/main/java/dev/phyce/naturalspeech/SpeechEventHandler.java
+++ b/src/main/java/dev/phyce/naturalspeech/SpeechEventHandler.java
@@ -107,7 +107,8 @@ public class SpeechEventHandler {
 			return;
 		}
 
-		textToSpeech.speak(voiceId, text, distance, username);
+		String queueName = config.serializeChatPlayback() ? MagicUsernames.CHAT : username;
+		textToSpeech.speak(voiceId, text, distance, queueName);
 	}
 
 	@Subscribe(priority=-100)

--- a/src/main/java/dev/phyce/naturalspeech/configs/NaturalSpeechConfig.java
+++ b/src/main/java/dev/phyce/naturalspeech/configs/NaturalSpeechConfig.java
@@ -39,6 +39,7 @@ public interface NaturalSpeechConfig extends Config {
 		public static final String SHORTENED_PHRASES = "shortenedPhrases";
 		public static final String HOLD_SHIFT_RIGHT_CLICK_MENU = "holdShiftRightClickMenu";
 		public static final String MUTE_GRAND_EXCHANGE_NPC_SPAM = "muteGrandExchangeNpcSpam";
+		public static final String SERIALIZE_CHAT_PLAYBACK = "serializeChatPlayback";
 	}
 
 	//<editor-fold desc="> General Settings">
@@ -126,6 +127,17 @@ public interface NaturalSpeechConfig extends Config {
 		section=generalSettingsSection
 	)
 	default boolean holdShiftRightClickMenu() {
+		return false;
+	}
+
+	@ConfigItem(
+		position=8,
+		keyName=ConfigKeys.SERIALIZE_CHAT_PLAYBACK,
+		name="Serialize chat playback",
+		description="Play chat messages in turn rather than overlapping. Each chatter currently has their own queue; turning this on routes all chat through a single queue.",
+		section=generalSettingsSection
+	)
+	default boolean serializeChatPlayback() {
 		return false;
 	}
 

--- a/src/main/java/dev/phyce/naturalspeech/tts/MagicUsernames.java
+++ b/src/main/java/dev/phyce/naturalspeech/tts/MagicUsernames.java
@@ -4,4 +4,5 @@ public final class MagicUsernames {
 	public static final String SYSTEM = "&system";
 	public static final String GLOBAL_NPC = "&globalnpc";
 	public static final String LOCAL_USER = "&localuser";
+	public static final String CHAT = "&chat";
 }


### PR DESCRIPTION
## Summary
- New `serializeChatPlayback` toggle under General Settings (default off).
- When on, the audio-queue name passed to `textToSpeech.speak` for chat messages is the new shared `MagicUsernames.CHAT` instead of the chatter's username — so all chat shares one queue and plays in turn.
- When off: original per-chatter queue behaviour.
- Dialog / NPC overhead / system messages keep their existing keys.

Closes #22.

## Test plan
- [ ] Default off: messages from multiple chatters can overlap as today.
- [ ] Enable `Serialize chat playback`: rapid-fire chat from several players reads one-after-another.
- [ ] Dialog still plays on its own queue (see PR #53).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

On behalf of @phyce