### PR TITLE
feat: per-source dedup for NPC overhead and system messages

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -57,6 +57,7 @@ Intergrated with [Spam Filter](https://runelite.net/plugin-hub/show/spamfilter) 
 - `Shortened phrases` are now `Abbreviations`
 - `Abbreviations` field is now `Custom abbreviations`
 - Added ability to skip NPC dialogs
+- Added ability to silence duplicate messages
 
 ## 1.2.6
 - Updated Menu event handler to work with the latest update affecting submenus

--- a/src/main/java/dev/phyce/naturalspeech/SpeechEventHandler.java
+++ b/src/main/java/dev/phyce/naturalspeech/SpeechEventHandler.java
@@ -7,6 +7,7 @@ import dev.phyce.naturalspeech.exceptions.ModelLocalUnavailableException;
 import dev.phyce.naturalspeech.exceptions.VoiceSelectionOutOfOption;
 import dev.phyce.naturalspeech.helpers.PluginHelper;
 import static dev.phyce.naturalspeech.helpers.PluginHelper.*;
+import dev.phyce.naturalspeech.spamdetection.MessageDuplicateSuppressor;
 import dev.phyce.naturalspeech.tts.MagicUsernames;
 import dev.phyce.naturalspeech.tts.MuteManager;
 import dev.phyce.naturalspeech.tts.TextToSpeech;
@@ -39,18 +40,21 @@ public class SpeechEventHandler {
 	private final VoiceManager voiceManager;
 	private final MuteManager muteManager;
 	private final SpamDetection spamDetection;
+	private final MessageDuplicateSuppressor duplicateSuppressor;
 
 	private final ClientThread clientThread;
 
 	@Inject
 	public SpeechEventHandler(Client client, TextToSpeech textToSpeech, NaturalSpeechConfig config,
-							  VoiceManager voiceManager, MuteManager muteManager, SpamDetection spamDetection, ClientThread clientThread) {
+							  VoiceManager voiceManager, MuteManager muteManager, SpamDetection spamDetection,
+							  MessageDuplicateSuppressor duplicateSuppressor, ClientThread clientThread) {
 		this.client = client;
 		this.textToSpeech = textToSpeech;
 		this.config = config;
 		this.voiceManager = voiceManager;
 		this.muteManager = muteManager;
 		this.spamDetection = spamDetection;
+		this.duplicateSuppressor = duplicateSuppressor;
 
 		this.clientThread = clientThread;
 	}
@@ -222,6 +226,7 @@ public class SpeechEventHandler {
 			if (isAreaDisabled()) return;
 			NPC npc = (NPC) event.getActor();
 			if (!muteManager.isNpcAllowed(npc)) return;
+			if (duplicateSuppressor.shouldSuppress("npc:" + npc.getName(), event.getOverheadText())) return;
 
 			int distance = PluginHelper.getActorDistance(event.getActor());
 
@@ -307,6 +312,19 @@ public class SpeechEventHandler {
 		return "Twitch".equals(message.getSender());
 	}
 
+	private static String duplicateSourceKey(ChatMessage message) {
+		switch (message.getType()) {
+			case ITEM_EXAMINE:
+			case NPC_EXAMINE:
+			case OBJECT_EXAMINE:
+				return "&examine";
+			case TRADEREQ:
+				return "tradereq:" + Text.standardize(message.getName());
+			default:
+				return MagicUsernames.SYSTEM;
+		}
+	}
+
 	public boolean isChatMessageMuted(ChatMessage message) {
 		if (message.getType() == ChatMessageType.AUTOTYPER) return true;
 		// dialog messages are handled in onWidgetLoad
@@ -363,9 +381,14 @@ public class SpeechEventHandler {
 			return true;
 		}
 
-		//noinspection RedundantIfStatement
 		if (spamDetection.isSpam(message.getName(), message.getMessage())) {
 			log.trace("Muting message. Spam detected. Message:{}", message.getMessage());
+			return true;
+		}
+
+		//noinspection RedundantIfStatement
+		if ((PluginHelper.isNPCChatMessage(message) || PluginHelper.isSystemMessage(message))
+			&& duplicateSuppressor.shouldSuppress(duplicateSourceKey(message), message.getMessage())) {
 			return true;
 		}
 
@@ -454,12 +477,12 @@ public class SpeechEventHandler {
 	}
 
 	private boolean isMutingOthers(ChatMessage message) {
-		if (isNPCChatMessage(message)) return false;
+		if (isNPCChatMessage(message) || isSystemMessage(message)) return false;
 		return config.muteOthers() && !message.getName().equals(PluginHelper.getLocalPlayerUsername());
 	}
 
 	private boolean checkMuteLevelThreshold(ChatMessage message) {
-		if (isNPCChatMessage(message)) return false;
+		if (isNPCChatMessage(message) || isSystemMessage(message)) return false;
 		if (Objects.equals(MagicUsernames.LOCAL_USER, message.getName())) return false;
 		if (message.getType() == ChatMessageType.PRIVATECHAT) return false;
 		if (message.getType() == ChatMessageType.PRIVATECHATOUT) return false;

--- a/src/main/java/dev/phyce/naturalspeech/configs/NaturalSpeechConfig.java
+++ b/src/main/java/dev/phyce/naturalspeech/configs/NaturalSpeechConfig.java
@@ -47,6 +47,7 @@ public interface NaturalSpeechConfig extends Config {
 		public static final String MUTE_GRAND_EXCHANGE_NPC_SPAM = "muteGrandExchangeNpcSpam";
 		public static final String FRIENDS_VOLUME_BOOST = "friendsVolumeBoost";
 		public static final String CUT_OFF_DIALOG_ON_SKIP = "cutOffDialogOnSkip";
+		public static final String MESSAGE_DUPLICATE_SUPPRESSOR = "messageDuplicateSuppressor";
 	}
 
 	//<editor-fold desc="> General Settings">
@@ -169,6 +170,17 @@ public interface NaturalSpeechConfig extends Config {
 	)
 	default boolean cutOffDialogOnSkip() {
 		return false;
+	}
+
+	@ConfigItem(
+		position=11,
+		keyName=ConfigKeys.MESSAGE_DUPLICATE_SUPPRESSOR,
+		name="Silence duplicate messages",
+		description="Prevents the same message from being constantly spammed",
+		section=generalSettingsSection
+	)
+	default boolean messageDuplicateSuppressorEnabled() {
+		return true;
 	}
 
 	//	@ConfigItem(

--- a/src/main/java/dev/phyce/naturalspeech/helpers/PluginHelper.java
+++ b/src/main/java/dev/phyce/naturalspeech/helpers/PluginHelper.java
@@ -153,19 +153,50 @@ public final class PluginHelper {
 //	}
 
 	public static boolean isPlayerChatMessage(@NonNull ChatMessage message) {
-		return !isNPCChatMessage(message);
+		switch (message.getType()) {
+			case PUBLICCHAT:
+			case MODCHAT:
+			case PRIVATECHAT:
+			case PRIVATECHATOUT:
+			case MODPRIVATECHAT:
+			case FRIENDSCHAT:
+			case CLAN_CHAT:
+			case CLAN_GUEST_CHAT:
+				return true;
+		}
+		return false;
 	}
 
 	public static boolean isNPCChatMessage(@NonNull ChatMessage message) {
-		// From NPC
 		switch (message.getType()) {
 			case DIALOG:
+				return true;
+		}
+		return false;
+	}
+
+	public static boolean isSystemMessage(@NonNull ChatMessage message) {
+		switch (message.getType()) {
 			case ITEM_EXAMINE:
 			case NPC_EXAMINE:
 			case OBJECT_EXAMINE:
 			case WELCOME:
 			case GAMEMESSAGE:
 			case CONSOLE:
+			case ENGINE:
+			case BROADCAST:
+			case LOGINLOGOUTNOTIFICATION:
+			case IGNORENOTIFICATION:
+			case TENSECTIMEOUT:
+			case CLAN_MESSAGE:
+			case CLAN_GUEST_MESSAGE:
+			case CLAN_CREATION_INVITATION:
+			case CLAN_GIM_FORM_GROUP:
+			case CLAN_GIM_GROUP_WITH:
+			case TRADE:
+			case TRADEREQ:
+			case PLAYERRELATED:
+			case AUTOTYPER:
 				return true;
 		}
 		return false;

--- a/src/main/java/dev/phyce/naturalspeech/spamdetection/MessageDuplicateSuppressor.java
+++ b/src/main/java/dev/phyce/naturalspeech/spamdetection/MessageDuplicateSuppressor.java
@@ -1,0 +1,49 @@
+package dev.phyce.naturalspeech.spamdetection;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import dev.phyce.naturalspeech.configs.NaturalSpeechConfig;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Singleton
+public class MessageDuplicateSuppressor {
+
+	private static final long WINDOW_MS = 5000;
+
+	private final NaturalSpeechConfig config;
+	private final Map<String, Entry> lastBySource = new HashMap<>();
+
+	@Inject
+	public MessageDuplicateSuppressor(NaturalSpeechConfig config) {
+		this.config = config;
+	}
+
+	public boolean shouldSuppress(String sourceKey, String text) {
+		if (!config.messageDuplicateSuppressorEnabled()) return false;
+		if (sourceKey == null || text == null || text.isEmpty()) return false;
+
+		long now = System.currentTimeMillis();
+		Entry last = lastBySource.get(sourceKey);
+
+		if (last != null && last.text.equals(text) && (now - last.timestampMs) < WINDOW_MS) {
+			log.trace("Suppressing repeated message from {}: {}", sourceKey, text);
+			return true;
+		}
+
+		lastBySource.put(sourceKey, new Entry(text, now));
+		return false;
+	}
+
+	private static final class Entry {
+		final String text;
+		final long timestampMs;
+
+		Entry(String text, long timestampMs) {
+			this.text = text;
+			this.timestampMs = timestampMs;
+		}
+	}
+}


### PR DESCRIPTION
Per-source 5-second cooldown for identical messages. Applies to NPC overhead and system messages; players are not deduped. Sending a different message from the same source resets the timer, so alternating lines always play.

On behalf of @phyce