### PR TITLE
Rework mute mode: explicit panel toggle, mode-gated right-click

### DIFF
--- a/src/main/java/dev/phyce/naturalspeech/MenuEventHandler.java
+++ b/src/main/java/dev/phyce/naturalspeech/MenuEventHandler.java
@@ -187,34 +187,7 @@ public class MenuEventHandler {
 
 			Menu subMenu = parent.createSubMenu();
 
-			if (isListened) {
-				subMenu.createMenuEntry(0)
-					.setOption("Unlisten")
-					.setType(MenuAction.RUNELITE)
-					.onClick(e -> {
-						if (npc != null) {
-							muteManager.unlistenNpc(npc);
-						}
-						else {
-							muteManager.unlistenUsername(standardActorName);
-						}
-					});
-			}
-			else {
-				subMenu.createMenuEntry(0)
-					.setOption("Listen")
-					.setType(MenuAction.RUNELITE)
-					.onClick(e -> {
-						if (npc != null) {
-							muteManager.listenNpc(npc);
-						}
-						else {
-							muteManager.listenUsername(standardActorName);
-						}
-						muteManager.setListenMode(true);
-					});
-			}
-
+			// Configure is shown in both modes.
 			{
 				final String value = voiceID != null ? voiceID.toVoiceIDString() : "";
 				subMenu.createMenuEntry(1)
@@ -229,18 +202,39 @@ public class MenuEventHandler {
 					});
 			}
 
+			// The primary action is decided by the active mute mode. The mode
+			// itself is set from the plugin panel, never from the right-click.
 			if (muteManager.isListenMode()) {
-				subMenu.createMenuEntry(1)
-					.setOption("Stop Listen Mode")
-					.setType(MenuAction.RUNELITE)
-					.onClick(e -> {
-						muteManager.setListenMode(false);
-						muteManager.clearListens();
-					});
+				if (isListened) {
+					subMenu.createMenuEntry(0)
+						.setOption("Unlisten")
+						.setType(MenuAction.RUNELITE)
+						.onClick(e -> {
+							if (npc != null) {
+								muteManager.unlistenNpc(npc);
+							}
+							else {
+								muteManager.unlistenUsername(standardActorName);
+							}
+						});
+				}
+				else {
+					subMenu.createMenuEntry(0)
+						.setOption("Listen")
+						.setType(MenuAction.RUNELITE)
+						.onClick(e -> {
+							if (npc != null) {
+								muteManager.listenNpc(npc);
+							}
+							else {
+								muteManager.listenUsername(standardActorName);
+							}
+						});
+				}
 			}
 			else {
 				if (isUnmuted) {
-					subMenu.createMenuEntry(1)
+					subMenu.createMenuEntry(0)
 						.setOption("Mute")
 						.setType(MenuAction.RUNELITE)
 						.onClick(e -> {
@@ -251,10 +245,9 @@ public class MenuEventHandler {
 								muteManager.muteUsername(standardActorName);
 							}
 						});
-
 				}
 				else {
-					subMenu.createMenuEntry(1)
+					subMenu.createMenuEntry(0)
 						.setOption("Unmute")
 						.setType(MenuAction.RUNELITE)
 						.onClick(e -> {

--- a/src/main/java/dev/phyce/naturalspeech/ui/panels/MainSettingsPanel.java
+++ b/src/main/java/dev/phyce/naturalspeech/ui/panels/MainSettingsPanel.java
@@ -2,6 +2,7 @@ package dev.phyce.naturalspeech.ui.panels;
 
 import com.google.inject.Inject;
 import dev.phyce.naturalspeech.tts.ModelRepository;
+import dev.phyce.naturalspeech.tts.MuteManager;
 import dev.phyce.naturalspeech.configs.NaturalSpeechConfig;
 import dev.phyce.naturalspeech.configs.NaturalSpeechRuntimeConfig;
 import dev.phyce.naturalspeech.downloader.Downloader;
@@ -73,6 +74,7 @@ public class MainSettingsPanel extends PluginPanel {
 	private final ModelRepository modelRepository;
 	private final TextToSpeech textToSpeech;
 	private final NaturalSpeechRuntimeConfig runtimeConfig;
+	private final MuteManager muteManager;
 	private final List<ModelRepository.ModelRepositoryListener> modelRepositoryListeners;
 
 	@Inject
@@ -82,13 +84,15 @@ public class MainSettingsPanel extends PluginPanel {
 		ConfigManager configManager,
 		Downloader downloader, ClientThread clientThread,
 		TextToSpeech textToSpeech,
-		NaturalSpeechRuntimeConfig runtimeConfig
+		NaturalSpeechRuntimeConfig runtimeConfig,
+		MuteManager muteManager
 	) {
 		super(false);
 		this.textToSpeech = textToSpeech;
 		this.modelRepository = modelRepository;
 		this.clientThread = clientThread;
 		this.runtimeConfig = runtimeConfig;
+		this.muteManager = muteManager;
 		this.modelRepositoryListeners = new ArrayList<>();
 
 		this.setLayout(new BorderLayout());
@@ -115,6 +119,7 @@ public class MainSettingsPanel extends PluginPanel {
 
 		buildHeaderSegment();
 		buildPiperStatusSection();
+		buildMuteModeSegment();
 		buildVoiceRepositorySegment();
 //		buildVoiceHistorySegment();
 
@@ -197,6 +202,88 @@ public class MainSettingsPanel extends PluginPanel {
 		instructionsLink.setBorder(new EmptyBorder(0, 0, 5, 0));
 		mainContentPanel.add(instructionsLink);
 
+	}
+
+	public void buildMuteModeSegment() {
+		final JPanel section = new JPanel();
+		section.setLayout(new BoxLayout(section, BoxLayout.Y_AXIS));
+		section.setMinimumSize(new Dimension(PANEL_WIDTH, 0));
+
+		final JPanel sectionHeader = new JPanel();
+		sectionHeader.setLayout(new BorderLayout());
+		sectionHeader.setMinimumSize(new Dimension(PANEL_WIDTH, 0));
+		sectionHeader.setBorder(new CompoundBorder(
+			new MatteBorder(0, 0, 1, 0, ColorScheme.MEDIUM_GRAY_COLOR),
+			new EmptyBorder(0, 0, 3, 1)));
+		section.add(sectionHeader);
+
+		final JButton sectionToggle = new JButton(SECTION_RETRACT_ICON);
+		sectionToggle.setPreferredSize(new Dimension(18, 0));
+		sectionToggle.setBorder(new EmptyBorder(0, 0, 0, 5));
+		sectionToggle.setToolTipText("Retract");
+		SwingUtil.removeButtonDecorations(sectionToggle);
+		sectionHeader.add(sectionToggle, BorderLayout.WEST);
+
+		final String name = "Mute Settings";
+		final String description =
+			"Choose between blocklist (mute the listed players/NPCs) and allowlist (only listen to the listed players/NPCs).";
+		final JLabel sectionName = new JLabel(name);
+		sectionName.setForeground(ColorScheme.BRAND_ORANGE);
+		sectionName.setFont(FontManager.getRunescapeBoldFont());
+		sectionName.setToolTipText("<html>" + name + ":<br>" + description + "</html>");
+		sectionHeader.add(sectionName, BorderLayout.CENTER);
+
+		final JPanel sectionContent = new JPanel();
+		sectionContent.setLayout(new DynamicGridLayout(0, 1, 0, 5));
+		sectionContent.setMinimumSize(new Dimension(PANEL_WIDTH, 0));
+		section.setBorder(new CompoundBorder(
+			new MatteBorder(0, 0, 1, 0, ColorScheme.MEDIUM_GRAY_COLOR),
+			new EmptyBorder(BORDER_OFFSET, 0, BORDER_OFFSET, 0)
+		));
+		section.add(sectionContent, BorderLayout.SOUTH);
+
+		mainContentPanel.add(section);
+
+		final MouseAdapter adapter = new MouseAdapter() {
+			@Override
+			public void mouseClicked(MouseEvent e) {
+				toggleSection(sectionToggle, sectionContent);
+			}
+		};
+		sectionToggle.addActionListener(actionEvent -> toggleSection(sectionToggle, sectionContent));
+		sectionName.addMouseListener(adapter);
+		sectionHeader.addMouseListener(adapter);
+
+		final JLabel modeLabel = new JLabel();
+		modeLabel.setBorder(new EmptyBorder(5, 5, 0, 5));
+
+		final JButton modeToggle = new JButton();
+		modeToggle.setFocusable(false);
+
+		final Runnable refresh = () -> {
+			if (muteManager.isListenMode()) {
+				modeLabel.setText(
+					"<html><b>Allowlist</b> mode — only listed players/NPCs are spoken.<br>" +
+					"Use right-click \"Listen\" / \"Unlisten\" to manage the list.</html>");
+				modeToggle.setText("Switch to Blocklist (Mute) mode");
+			}
+			else {
+				modeLabel.setText(
+					"<html><b>Blocklist</b> mode — everyone is spoken except listed players/NPCs.<br>" +
+					"Use right-click \"Mute\" / \"Unmute\" to manage the list.</html>");
+				modeToggle.setText("Switch to Allowlist (Listen) mode");
+			}
+		};
+		refresh.run();
+
+		modeToggle.addActionListener(e -> {
+			muteManager.setListenMode(!muteManager.isListenMode());
+			muteManager.saveConfig();
+			refresh.run();
+		});
+
+		sectionContent.add(modeLabel);
+		sectionContent.add(modeToggle);
 	}
 
 	public void buildVoiceRepositorySegment() {


### PR DESCRIPTION
## Summary

Right-clicking \"Listen\" on a player or NPC currently calls \`setListenMode(true)\` behind the scenes, flipping the entire mute system from blocklist (default) to allowlist mode. This is the most common confusion report about the plugin — users want to listen to one person and end up silencing everyone else with no obvious recovery path.

This PR makes the mode an explicit, panel-driven setting and removes the silent flip:

- **New \"Mute Settings\" panel section** with a button that toggles between blocklist (Mute these) and allowlist (Listen to only these) modes. The mode is the sole switch, and it persists immediately via \`muteManager.saveConfig()\`.
- **Right-click is now mode-aware**:
  - Blocklist mode → primary action is \`Mute\` / \`Unmute\`.
  - Allowlist mode → primary action is \`Listen\` / \`Unlisten\`.
  - The \"Stop Listen Mode\" sub-entry is removed (the panel owns the mode).
- **Both lists are preserved across mode switches** — toggling no longer calls \`clearListens()\`. Users can switch back and forth without losing their settings.

The \`MuteManager\` API is unchanged; only the call sites for \`setListenMode\` move. \`isNpcAllowed\` / \`isUsernameAllowed\` continue to honor the active mode for the speech path.

Closes Asana task *\"rework mute system: explicit allow/block toggle in panel\"*.

### Out of scope

- The right-click \`Mute\`/\`Listen\` actions still don't call \`saveConfig()\` (pre-existing — mute lists persist only on plugin shutdown). Tracked separately.
- A panel view of the current allowlist/blocklist contents (Asana *view allow/blocklist from panel menu*) is a natural follow-up.

## Test plan

- [ ] Fresh install: panel section shows \"Blocklist mode\". Right-click a player → \"Mute\" / \"Unmute\".
- [ ] Toggle the panel button to allowlist mode → label updates, right-click on the same player now shows \"Listen\" / \"Unlisten\".
- [ ] Add a player to the allowlist, switch back to blocklist mode → the allowlist entry is preserved (verify by switching to allowlist mode again).
- [ ] Restart the client → mode and both lists persist.
- [ ] Existing users mid-listen-mode-because-they-clicked-Listen: panel shows allowlist mode, they can flip it back from the panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

On behalf of @phyce