### PR TITLE
Fix containAlphaNumeric() to actually include digits

### DIFF
--- a/src/main/java/dev/phyce/naturalspeech/utils/TextUtil.java
+++ b/src/main/java/dev/phyce/naturalspeech/utils/TextUtil.java
@@ -89,7 +89,7 @@ public final class TextUtil {
 		return tokens;
 	}
 
-	public static final Pattern patternAnyAlphaNumericChar = Pattern.compile(".*[A-Za-zÀ-ÖØ-öø-ÿ].*");
+	public static final Pattern patternAnyAlphaNumericChar = Pattern.compile(".*[A-Za-z0-9À-ÖØ-öø-ÿ].*");
 	public static boolean containAlphaNumeric(String text) {
 		return patternAnyAlphaNumericChar.matcher(text).matches();
 	}


### PR DESCRIPTION
## Summary

`TextUtil.containAlphaNumeric` is supposed to return true when a message has *any* alphanumeric character — its purpose, per the caller in `SpeechEventHandler.isChatMessageMuted`, is to mute symbol-only spam like `::::::))))))`. But the underlying regex is

```java
".*[A-Za-zÀ-ÖØ-öø-ÿ].*"
```

— letters only, no digits. So a pure-numeric message like `10000` returns `false` and gets muted. `1000 test 1000` works because of the letters.

Fix: add `0-9` to the character class. Same fix already exists on master / 2.0.0 (`utils/TextUtil.java` in the rewrite has the corrected class). One-character change.

## Test plan

- [ ] Send a public chat message of just `10000` — gets spoken.
- [ ] Send a system message containing only digits — gets spoken.
- [ ] Send `::::::))))))` — still muted (symbols only).
- [ ] Send `1000 test 1000` — still spoken (unchanged behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

On behalf of @phyce
