### PR TITLE
Audit ChatMessageType coverage end-to-end

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -41,6 +41,7 @@ Intergrated with [Spam Filter](https://runelite.net/plugin-hub/show/spamfilter) 
 
 ## 1.3.0
 - Fixed numbers with commas in system messages not being read correctly
+- Audit of `ChatMessageType` coverage: previously-dropped message types (challenge requests, trade sent, friend list changes, etc.) now speak; all system message types respect the System messages toggle; new "Did you know?" and "Level up messages" toggles (both off by default)
 
 ## 1.2.6
 - Updated Menu event handler to work with the latest update affecting submenus

--- a/src/main/java/dev/phyce/naturalspeech/SpeechEventHandler.java
+++ b/src/main/java/dev/phyce/naturalspeech/SpeechEventHandler.java
@@ -199,11 +199,11 @@ public class SpeechEventHandler {
 			case PUBLICCHAT:
 				return Objects.equals(Text.standardize(message.getName()), getLocalPlayerUsername());
 			case PRIVATECHATOUT:
-			case MODPRIVATECHAT:
 			case ITEM_EXAMINE:
 			case NPC_EXAMINE:
 			case OBJECT_EXAMINE:
 			case TRADEREQ:
+			case TRADE_SENT:
 				return true;
 			default:
 				return false;
@@ -233,6 +233,9 @@ public class SpeechEventHandler {
 			case LOGINLOGOUTNOTIFICATION:
 			case BROADCAST:
 			case IGNORENOTIFICATION:
+			case FRIENDNOTIFICATION:
+			case FRIENDSCHATNOTIFICATION:
+			case SNAPSHOTFEEDBACK:
 			case CLAN_MESSAGE:
 			case CONSOLE:
 			case TRADE:
@@ -243,6 +246,11 @@ public class SpeechEventHandler {
 			case CLAN_GIM_FORM_GROUP:
 			case CLAN_GIM_GROUP_WITH:
 			case GAMEMESSAGE:
+			case DIDYOUKNOW:
+			case LEVELUPMESSAGE:
+			case CHALREQ_TRADE:
+			case CHALREQ_FRIENDSCHAT:
+			case CHALREQ_CLANCHAT:
 				return true;
 			default:
 				return false;
@@ -250,7 +258,12 @@ public class SpeechEventHandler {
 	}
 
 	public boolean isChatMessageMuted(ChatMessage message) {
+		// AUTOTYPER and MODAUTOTYPER are always muted - they're the in-game
+		// "autotyper" mechanism we have no reason to voice. SPAM is content
+		// that the game (or our SpamFilter) has already flagged - don't speak it.
 		if (message.getType() == ChatMessageType.AUTOTYPER) return true;
+		if (message.getType() == ChatMessageType.MODAUTOTYPER) return true;
+		if (message.getType() == ChatMessageType.SPAM) return true;
 		// dialog messages are handled in onWidgetLoad
 		if (message.getType() == ChatMessageType.DIALOG) return true;
 
@@ -358,9 +371,35 @@ public class SpeechEventHandler {
 			case WELCOME:
 			case GAMEMESSAGE:
 			case CONSOLE:
+			case ENGINE:
+			case BROADCAST:
+			case IGNORENOTIFICATION:
+			case TRADE:
+			case PLAYERRELATED:
+			case TENSECTIMEOUT:
+			case SNAPSHOTFEEDBACK:
+			case CLAN_GIM_FORM_GROUP:
+			case CLAN_GIM_GROUP_WITH:
 				if (!config.systemMesagesEnabled()) return true;
 				break;
+			case LOGINLOGOUTNOTIFICATION:
+			case FRIENDNOTIFICATION:
+			case FRIENDSCHATNOTIFICATION:
+				if (!config.friendsChatEnabled()) return true;
+				if (!config.systemMesagesEnabled()) return true;
+				break;
+			case CLAN_CREATION_INVITATION:
+				if (!config.clanChatEnabled()) return true;
+				if (!config.systemMesagesEnabled()) return true;
+				break;
+			case DIDYOUKNOW:
+				if (!config.didYouKnowEnabled()) return true;
+				break;
+			case LEVELUPMESSAGE:
+				if (!config.levelUpMessagesEnabled()) return true;
+				break;
 			case TRADEREQ:
+			case TRADE_SENT:
 			case CHALREQ_CLANCHAT:
 			case CHALREQ_FRIENDSCHAT:
 			case CHALREQ_TRADE:

--- a/src/main/java/dev/phyce/naturalspeech/configs/NaturalSpeechConfig.java
+++ b/src/main/java/dev/phyce/naturalspeech/configs/NaturalSpeechConfig.java
@@ -39,6 +39,8 @@ public interface NaturalSpeechConfig extends Config {
 		public static final String SHORTENED_PHRASES = "shortenedPhrases";
 		public static final String HOLD_SHIFT_RIGHT_CLICK_MENU = "holdShiftRightClickMenu";
 		public static final String MUTE_GRAND_EXCHANGE_NPC_SPAM = "muteGrandExchangeNpcSpam";
+		public static final String DID_YOU_KNOW = "didYouKnow";
+		public static final String LEVEL_UP_MESSAGES = "levelUpMessages";
 	}
 
 	//<editor-fold desc="> General Settings">
@@ -283,6 +285,28 @@ public interface NaturalSpeechConfig extends Config {
 	)
 	default boolean systemMesagesEnabled() {
 		return true;
+	}
+
+	@ConfigItem(
+		keyName=ConfigKeys.DID_YOU_KNOW,
+		name="\"Did you know?\" tips",
+		description="Speak the periodic \"Did you know?\" tips the game shows.",
+		section=ttsOptionsSection,
+		position=13
+	)
+	default boolean didYouKnowEnabled() {
+		return false;
+	}
+
+	@ConfigItem(
+		keyName=ConfigKeys.LEVEL_UP_MESSAGES,
+		name="Level up messages",
+		description="Speak the \"Check the skill guide\" message that fires alongside the level-up jingle.",
+		section=ttsOptionsSection,
+		position=14
+	)
+	default boolean levelUpMessagesEnabled() {
+		return false;
 	}
 	//</editor-fold>
 


### PR DESCRIPTION
## Summary

End-to-end pass over `net.runelite.api.ChatMessageType`. Every value is now either explicitly voiced (with a sensible config gate) or explicitly muted — no more silent drops through the "didn't match" branch.

### Bug fixes

| # | What | Was | Now |
|---|------|-----|-----|
| 1 | `MODPRIVATECHAT` duplicated in both `isChatInnerVoice` and `isChatOtherPlayerVoice` | Incoming PM from a mod spoke in **your** voice (inner won the if/else) | Removed from inner; mod's PM uses the mod's voice via other-player path |
| 2 | `CHALREQ_TRADE` / `CHALREQ_FRIENDSCHAT` / `CHALREQ_CLANCHAT` had a request-gate but no voice routing | Even with requests enabled, these fell through and never spoke | Added to `isChatSystemVoice` |

### Voice routing for previously-dropped types

- `TRADE_SENT` → inner voice (it's your own action)
- `FRIENDNOTIFICATION` / `FRIENDSCHATNOTIFICATION` / `SNAPSHOTFEEDBACK` / `DIDYOUKNOW` / `LEVELUPMESSAGE` → system voice
- `SPAM` / `MODAUTOTYPER` → always muted (matches existing `AUTOTYPER`)

### System-message gating consistency

Previously only `GAMEMESSAGE` / `WELCOME` / `CONSOLE` actually respected `systemMesagesEnabled`. Now all system-voice types do:

- `ENGINE`, `BROADCAST`, `IGNORENOTIFICATION`, `TRADE`, `PLAYERRELATED`, `TENSECTIMEOUT`, `SNAPSHOTFEEDBACK`, `CLAN_GIM_FORM_GROUP`, `CLAN_GIM_GROUP_WITH` → gated on `systemMesagesEnabled`.

### Dual-gating (channel + system)

Following the precedent PR #40 set for `CLAN_MESSAGE`:

- `LOGINLOGOUTNOTIFICATION`, `FRIENDNOTIFICATION`, `FRIENDSCHATNOTIFICATION` → `friendsChat` AND `systemMesages` (these are system messages *about* friends).
- `CLAN_CREATION_INVITATION` → `clanChat` AND `systemMesages`.

### New toggles (Speech Generation section)

| Key | Default | What |
|-----|---------|------|
| `didYouKnow` | off | Speak the periodic "Did you know?" tips. |
| `levelUpMessages` | off | Speak the "Check the skill guide" line that fires with the level-up jingle. |

Both default off — they're frequent and most users probably don't want them.

### Request-class

- `TRADE_SENT` → `requestsEnabled` (joins existing `TRADEREQ` / `CHALREQ_*`).

## Out of scope / follow-ups

- `MESBOX` (dialog box / book pages) needs widget plumbing like `DIALOG` already has — separate PR.
- `NPC_SAY` likely duplicates `OverheadTextChanged` events — leaving until verified to avoid double-speech.
- `CLAN_GIM_FORM_GROUP` / `CLAN_GIM_GROUP_WITH` are gated on `systemMesages` alone here. After PR #47 lands they should be dual-gated on `groupIronmanChatEnabled + systemMesages` to match `CLAN_GIM_MESSAGE`.
- PR #40 also adds `CLAN_GUEST_MESSAGE` to `isChatSystemVoice` and gates it on `clanGuestChat + system`. Whichever of these two PRs merges second will hit a trivial conflict in those same locations — keep both branches' additions.

## Test plan

- [ ] Receive a PM from an actual mod → speaks in the mod's voice (not yours).
- [ ] Send a duel request → voiced (with `requests` enabled).
- [ ] Send a trade request → voiced (with `requests` enabled).
- [ ] Friend logs in → voiced only when both `friendsChat` AND `systemMesages` are on.
- [ ] Add someone to friends list → "X has been added to your friend list" voiced only with friends + system on.
- [ ] Toggle `didYouKnow` on → next "Did you know?" tip speaks.
- [ ] Toggle `levelUpMessages` on → next level-up "Check the skill guide" line speaks.
- [ ] Turn `systemMesages` off → all system types fall silent (login/logout, broadcasts, trade complete, etc.).
- [ ] AUTOTYPER / MODAUTOTYPER / SPAM messages never speak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

On behalf of @phyce
