### PR TITLE
Fix mute-below-level muting players whose level couldn't be looked up

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -57,6 +57,7 @@ Intergrated with [Spam Filter](https://runelite.net/plugin-hub/show/spamfilter) 
 - `Shortened phrases` are now `Abbreviations`
 - `Abbreviations` field is now `Custom abbreviations`
 - Added ability to skip NPC dialogs
+- Mute-below-level no longer mutes off-world players
 
 ## 1.2.6
 - Updated Menu event handler to work with the latest update affecting submenus

--- a/src/main/java/dev/phyce/naturalspeech/SpeechEventHandler.java
+++ b/src/main/java/dev/phyce/naturalspeech/SpeechEventHandler.java
@@ -465,10 +465,12 @@ public class SpeechEventHandler {
 		if (message.getType() == ChatMessageType.PRIVATECHATOUT) return false;
 		if (message.getType() == ChatMessageType.CLAN_CHAT) return false;
 		if (message.getType() == ChatMessageType.CLAN_GUEST_CHAT) return false;
+
+		int level = getLevel(message.getName());
+		if (level == 0) return false;
+
 		//noinspection RedundantIfStatement
-		if (getLevel(message.getName()) < config.muteLevelThreshold()) return true;
-
-
+		if (level < config.muteLevelThreshold()) return true;
 		return false;
 	}
 


### PR DESCRIPTION
## Summary

`checkMuteLevelThreshold` was muting messages from players whose combat level the plugin couldn't actually look up. With "Below level 10" set, *everyone* in friends chat or anyone too far to render got muted instead of just sub-level-10 players.

### Root cause

`PluginHelper.getLevel(username)` does:

```java
Player target = findPlayerWithUsername(username);   // searches local world view only
if (target == null) return 0;
return target.getCombatLevel();
```

If the player isn't in the current world view — a friends-chat member on another world, a player out of render distance, a clan member, anyone you can't see — it returns `0`.

The threshold check was then:

```java
if (getLevel(message.getName()) < config.muteLevelThreshold()) return true;
```

`@Range(min=3, max=126)` means `muteLevelThreshold` is always ≥ 3, so `0 < 3` was true for the default and silently muted every off-screen author. Anything you set the slider to made things *more* muted, not less.

RuneLite's `FriendsChatMember` / `ClanChannelMember` APIs don't carry combat level — there's no other source to read it from when the player isn't visible — so the correct fix is to treat level 0 as "unknown" and let the message through.

### Fix

```java
int level = getLevel(message.getName());
if (level <= 0) return false;          // unknown; can't filter
if (level < config.muteLevelThreshold()) return true;
return false;
```

Anyone we *can* see (nearby in the world view) keeps the threshold behavior. Anyone we can't see — friends chat, distant public chat — is no longer auto-muted.

## Test plan

- [ ] Threshold = 3 (default) → nobody muted by the threshold (current minimum).
- [ ] Threshold = 10 → a visible level-5 player in public chat is muted; a visible level-50 player speaks.
- [ ] Threshold = 10 → friends-chat members on other worlds speak (previously muted regardless of their real level).
- [ ] Threshold = 126 → only locally-visible non-max-level players are muted; off-world friends still speak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

On behalf of @phyce
