### PR TITLE
Strip tags from examine text

### DIFF
--- a/src/main/java/dev/phyce/naturalspeech/SpeechEventHandler.java
+++ b/src/main/java/dev/phyce/naturalspeech/SpeechEventHandler.java
@@ -75,6 +75,22 @@ public class SpeechEventHandler {
 			if (isChatInnerVoice(message)) {
 				username = MagicUsernames.LOCAL_USER;
 				distance = 0;
+				// Examines are game-generated and can carry <col>/<img> tags
+				// from other plugins (price overlays etc). Strip them so the
+				// tag name isn't spoken aloud. The other inner-voice cases
+				// (PUBLICCHAT from local player, PRIVATECHATOUT, MODPRIVATECHAT,
+				// TRADEREQ) are user-typed or contain a username; their <lt>/<gt>
+				// decoded content shouldn't be tag-stripped or we'd eat literal
+				// "<word>" content.
+				switch (message.getType()) {
+					case ITEM_EXAMINE:
+					case NPC_EXAMINE:
+					case OBJECT_EXAMINE:
+						text = Text.removeTags(text);
+						break;
+					default:
+						break;
+				}
 				voiceId = voiceManager.getVoiceIDFromUsername(username);
 				text = textToSpeech.expandShortenedPhrases(text);
 


### PR DESCRIPTION
## Summary

Examine messages (`ITEM_EXAMINE`, `NPC_EXAMINE`, `OBJECT_EXAMINE`) are routed through the inner-voice branch of `onChatMessage`, which never calls `Text.removeTags`. Other RuneLite plugins (price overlays, custom examine info, etc.) commonly wrap examine text with `<col=..>` / `<img=..>` tags — TTS then speaks the tag name literally ("colNORMAL ...").

Add `Text.removeTags` only for the three EXAMINE types inside the inner-voice branch.

## What this PR does *not* do

I initially tried a universal `removeTags` at the top of `onChatMessage`. That was wrong — `<lt>` and `<gt>` are the game's escapes for user-typed `<` and `>`, and the existing decode at the top re-creates literal angle brackets in player chat. Running `removeTags` after that would strip user content like `<word>` typed in chat. Reverted that approach.

The selective fix here:

- **System-voice branch** — already calls `Text.removeTags`. Unchanged.
- **Inner-voice branch, examine cases** — new strip (this PR).
- **Inner-voice branch, user-typed cases** (`PUBLICCHAT` from local, `PRIVATECHATOUT`, `MODPRIVATECHAT`, `TRADEREQ`) — untouched. Game escapes user `<`/`>` as `<lt>`/`<gt>`, the existing decode handles it.
- **Other-player-voice branch** — untouched. Same reasoning as above.
- **Twitch chat** — PR #46 handles its specific `<colNORMAL>` strip on the FRIENDSCHAT path. Correct approach for plugin-injected tags in user-chat paths.

## Test plan

- [ ] Examine an item with the Item Stats plugin enabled → only the description speaks, no color-tag name.
- [ ] Examine an NPC / object → same.
- [ ] Type `<word>` in public chat → still spoken as "less than word greater than" (or however TTS pronounces the brackets). Not silenced.
- [ ] Type `<3 you` → still spoken (no closing `>` so even if a stripper ran it'd survive; verifying baseline).
- [ ] Send a PM containing angle brackets → spoken intact.
- [ ] System messages (game broadcasts etc.) → already strip tags via existing path, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

On behalf of @phyce