### PR TITLE
docs: port new feature sections from master + fix badge urls

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -14,6 +14,12 @@ You can use the Included voice explorer to preview a voice:<br/>
 Explore the many customization options to fine-tune your TTS experience:<br/>
 ![](https://mechanic.ink/img/osrs/features/config.png)
 
+### Party options
+You can make your friends messages sound louder by adjusting the `Friends volume boost`, or you can listen to them exclusively by using `Friends only mode`. Set a limit of how many people there is around you before the plugin stops generating audio clips.
+
+### Friends volume boost
+You can boost the volume of your friends to make them sound louder than the rest of the players.
+
 ### Spam Prevention
 
 Intergrated with [Spam Filter](https://runelite.net/plugin-hub/show/spamfilter) and [Chat Filter](https://github.com/runelite/runelite/wiki/Chat-Filter) so you don't have to listen to spam!<br/>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Natural Speech [![Plugin Installs](http://img.shields.io/endpoint?url=https://i.pluginhub.info/shields/installs/plugin/naturalspeech)](https://runelite.net/plugin-hub/show/naturalspeech) [![Plugin Rank](http://img.shields.io/endpoint?url=https://i.pluginhub.info/shields/rank/plugin/naturalspeech)](https://runelite.net/plugin-hub)
+# Natural Speech [![Active Installs](http://img.shields.io/endpoint?url=https://api.runelite.net/pluginhub/shields/installs/plugin/naturalspeech)](https://runelite.net/plugin-hub/show/naturalspeech) [![Plugin Rank](http://img.shields.io/endpoint?url=https://api.runelite.net/pluginhub/shields/rank/plugin/naturalspeech)](https://runelite.net/plugin-hub)
 
 
 Give everyone a voice in OldSchool RuneScape! For all characters and players, with over 1000 different voices.


### PR DESCRIPTION
Pulls forward the changes from master's docs that apply to 1.3.0:

- Adds **Party options** and **Friends volume boost** sections to FEATURES.md (both features already ship in 1.3.0).
- Updates README badge URLs to `api.runelite.net/pluginhub/shields/...`; the old `i.pluginhub.info` endpoints no longer return shields.

Engine-specific docs (Voice Hub UI, Gary Gilbert/SAPI 4, Windows installer, additional engine setup) are intentionally not ported.

On behalf of @phyce